### PR TITLE
fix(storage): Opt out of CloudKit by default for SwiftData container

### DIFF
--- a/Catbird/Catbird/Core/Storage/ContainerFactory.swift
+++ b/Catbird/Catbird/Core/Storage/ContainerFactory.swift
@@ -9,6 +9,7 @@ enum ContainerFactory {
   ) throws -> ModelContainer {
     let cloudConfig: ModelConfiguration
     if let id = cloudContainerIdentifier {
+      // Explicitly enable CloudKit only when identifier is provided
       cloudConfig = ModelConfiguration(
         _ : "Cloud",
         schema: Schema([AppSettings.self, Draft.self, DraftAttachment.self]),
@@ -17,10 +18,8 @@ enum ContainerFactory {
         cloudKitDatabase: .private(id)
       )
     } else {
-      cloudConfig = ModelConfiguration(
-        for: [AppSettings.self, Draft.self, DraftAttachment.self],
-        isStoredInMemoryOnly: false
-      )
+      // Opt out of automatic CloudKit detection by default to avoid schema constraints
+      cloudConfig = ModelConfiguration(cloudKitDatabase: .none)
     }
 
     let container = try ModelContainer(


### PR DESCRIPTION
Disable SwiftData’s automatic CloudKit adoption by default to prevent schema constraint errors when iCloud entitlement is present.

- ContainerFactory.make(): use `ModelConfiguration(cloudKitDatabase: .none)` when no explicit identifier is provided
- Keeps explicit CloudKit only when an identifier is passed

This avoids the runtime crash you saw where SwiftData attempted CloudKit integration and Core Data reported non‑optional attributes / unique constraints.

Follow‑up: Wire ContainerFactory into `CatbirdApp` to use this safe default until CloudKit schema is ready for the SwiftData models.
