### PR TITLE
Catbird: handle resetRequestedEvent for Phase 2.5

### DIFF
--- a/Catbird/Core/State/AppState.swift
+++ b/Catbird/Core/State/AppState.swift
@@ -2304,6 +2304,18 @@ final class AppState {
                 self.stateInvalidationBus.notify(.mlsConversationListChanged)
               }
             },
+            onResetRequested: { [weak self] event in
+              guard let self else { return }
+              self.logger.warning(
+                "MLS WS [global]: reset requested for \(event.convoId.prefix(8)) (gen \(event.generation), trigger=\(event.trigger))"
+              )
+              if let manager = await self.getMLSConversationManager() {
+                await manager.handleResetRequested(event: event)
+              }
+              await MainActor.run {
+                self.stateInvalidationBus.notify(.mlsConversationListChanged)
+              }
+            },
             onReconnected: { [weak self] in
               guard let self else { return }
               self.logger.info("MLS WS [global]: reconnected — refreshing all conversations")

--- a/Catbird/Core/State/AppState.swift
+++ b/Catbird/Core/State/AppState.swift
@@ -2307,7 +2307,7 @@ final class AppState {
             onResetRequested: { [weak self] event in
               guard let self else { return }
               self.logger.warning(
-                "MLS WS [global]: reset requested for \(event.convoId.prefix(8)) (gen \(event.generation), trigger=\(event.trigger))"
+                "MLS WS [global]: reset requested for \(event.convoId.prefix(8)) (gen \(event.generation), trigger=\(event.trigger), requestEventId=\(event.requestEventId.prefix(16)), cryptoSessionId=\(event.cryptoSessionId.prefix(16)))"
               )
               if let manager = await self.getMLSConversationManager() {
                 await manager.handleResetRequested(event: event)

--- a/Catbird/Features/MLSChat/MLSConversationDetailView.swift
+++ b/Catbird/Features/MLSChat/MLSConversationDetailView.swift
@@ -3393,6 +3393,10 @@ struct MLSConversationDetailView: View {
             self.logger.info("📡 WS: onGroupReset handler called - convo: \(groupResetEvent.convoId.prefix(16))")
             await self.handleGroupResetEvent(groupResetEvent)
           },
+          onResetRequested: { @MainActor resetRequestedEvent in
+            self.logger.info("📡 WS: onResetRequested handler called - convo: \(resetRequestedEvent.convoId.prefix(16)), gen: \(resetRequestedEvent.generation), trigger: \(resetRequestedEvent.trigger)")
+            await self.handleResetRequestedEvent(resetRequestedEvent)
+          },
           onError: { @MainActor error in
             self.logger.error("📡 WS: onError handler called: \(error.localizedDescription)")
           },
@@ -3880,6 +3884,28 @@ struct MLSConversationDetailView: View {
       await manager.handleGroupReset(event: event)
     } else {
       logger.error("❌ [GroupReset] No conversation manager available")
+    }
+  }
+
+  /// Handle a Phase 2.5 indirect-trigger `resetRequestedEvent`.
+  ///
+  /// Mirrors `handleGroupResetEvent` shape: log the event, then delegate to
+  /// `MLSConversationManager.handleResetRequested(event:)` which deletes the
+  /// stale group, flags `RESET_PENDING`, and lets deferred recovery race-
+  /// bootstrap a fresh crypto session via the chokepoint UNIQUE constraint.
+  /// See `docs/plans/phase-2-5-indirect-funneling.md` §3.
+  @MainActor
+  private func handleResetRequestedEvent(
+    _ event: BlueCatbirdMlsChatSubscribeEvents.ResetRequestedEvent
+  ) async {
+    logger.info(
+      "🔄 [ResetRequested] Conversation \(event.convoId.prefix(16)) reset requested (gen \(event.generation), trigger=\(event.trigger), eventId=\(event.requestEventId.prefix(16)))"
+    )
+
+    if let manager = await appState.getMLSConversationManager() {
+      await manager.handleResetRequested(event: event)
+    } else {
+      logger.error("❌ [ResetRequested] No conversation manager available")
     }
   }
 

--- a/Catbird/Features/MLSChat/MLSConversationDetailView.swift
+++ b/Catbird/Features/MLSChat/MLSConversationDetailView.swift
@@ -3394,7 +3394,7 @@ struct MLSConversationDetailView: View {
             await self.handleGroupResetEvent(groupResetEvent)
           },
           onResetRequested: { @MainActor resetRequestedEvent in
-            self.logger.info("📡 WS: onResetRequested handler called - convo: \(resetRequestedEvent.convoId.prefix(16)), gen: \(resetRequestedEvent.generation), trigger: \(resetRequestedEvent.trigger)")
+            self.logger.warning("📡 WS: onResetRequested handler called - convo: \(resetRequestedEvent.convoId.prefix(16)), gen: \(resetRequestedEvent.generation), trigger: \(resetRequestedEvent.trigger)")
             await self.handleResetRequestedEvent(resetRequestedEvent)
           },
           onError: { @MainActor error in
@@ -3898,7 +3898,7 @@ struct MLSConversationDetailView: View {
   private func handleResetRequestedEvent(
     _ event: BlueCatbirdMlsChatSubscribeEvents.ResetRequestedEvent
   ) async {
-    logger.info(
+    logger.warning(
       "🔄 [ResetRequested] Conversation \(event.convoId.prefix(16)) reset requested (gen \(event.generation), trigger=\(event.trigger), eventId=\(event.requestEventId.prefix(16)))"
     )
 


### PR DESCRIPTION
## Summary

Phase 2.5 Wave 2 (`docs/plans/phase-2-5-indirect-funneling.md` §3, §4 iOS section). Wire the new `resetRequestedEvent` SSE event into both subscription paths: the global AppState WebSocket stream and the per-conversation MLSConversationDetailView stream. Mirrors the existing `groupResetEvent` flow exactly.

Pairs with the CatbirdMLSCore PR that ships the new handler + UniFFI regen: https://github.com/joshlacal/CatbirdMLSCore/pull/1

## Changes

- **Catbird/Core/State/AppState.swift**: add `onResetRequested` callback to the global MLS WebSocket subscription. Logs trigger + generation, delegates to `MLSConversationManager.handleResetRequested(event:)`, and notifies the conversation list invalidation bus — same shape as the existing `onGroupReset` callback above it.
- **Catbird/Features/MLSChat/MLSConversationDetailView.swift**: add the matching per-convo `onResetRequested` callback inside `startMessagePolling()` and a private `handleResetRequestedEvent` method that delegates to the manager. Mirrors `handleGroupResetEvent` exactly.

The MLS state machine work (delete stale group, mint client-side candidate id, flag `RESET_PENDING` with the candidate as `pendingNewGroupId`, kick the sync loop) lives entirely in CatbirdMLSCore's `MLSConversationManager.handleResetRequested(event:)`. Catbird's view layer does no MLS state mutation here.

## Why client-side mint instead of staging nil

Phase 2.5's first-responder election uses the existing recipient-then-bootstrap branch in `MLSConversationManager+Sync.swift`. That branch is keyed off `pendingNewGroupId != nil`. Leaving it nil routes the row through the admin-only `resetGroup` path (line 635) which fails with `notadmin` for non-admin members. Minting locally puts the row into the bootstrap-race path, where the server's chokepoint UNIQUE constraint elects exactly one winner across all responding clients. See the CatbirdMLSCore PR for the implementation + test.

## Test plan

- [x] CatbirdMLSCore tests: 7/7 pass (3 existing GroupReset + 4 new ResetRequested).
- [x] Catbird build: `xcodebuild ... -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build` — `BUILD SUCCEEDED`.
- [ ] Manual smoke: run against staging mls-ds emitting `resetRequestedEvent` and observe OSLog messages `MLS WS [global]: reset requested...` and `🔄 [ResetRequested] Conversation ...` (deferred — needs server Stage 1 deployed).

## Sim note

Dispatch asked for iPhone 16 simulator; not present in available runtimes — built against iPhone 17 Pro (iOS 26.4) which the project targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)