### PR TITLE
Catbird: fix Darwin self-loop on app-originated MLS mutations

### DIFF
--- a/Catbird/Features/Notifications/Services/NotificationManager.swift
+++ b/Catbird/Features/Notifications/Services/NotificationManager.swift
@@ -2712,28 +2712,32 @@ extension NotificationManager: UNUserNotificationCenterDelegate {
 
   /// Signal cross-process MLS mutations for non-active account foreground decoding.
   ///
-  /// This keeps lightweight decoding for inactive users while coordinating state
-  /// changes with monotonic versioning and Darwin notifications.
+  /// Darwin self-loop fix (2026-04): The cross-process `stateChanged` Darwin
+  /// notification and the disk version counter are NSE→app signals only. When
+  /// the main app posts/bumps them on its own mutations, the receiver-side
+  /// reload (and the in-process stale-context check) fires against ourselves —
+  /// causing a full MLSCoreContext teardown after every send/receive. We retain
+  /// the audit log via `publishMutation`, but pass `incrementVersion: false`
+  /// and `postStateChanged: false` regardless of the caller's request.
+  ///
+  /// Cross-process correctness for inactive users is preserved by SQLite WAL
+  /// persistence — NSE recreates `MLSCoreContext.shared` per invocation and
+  /// reads disk state from scratch, so it never consults the in-memory version.
   private func signalInactiveAccountStateMutation(
     for userDid: String,
     source: String,
-    incrementVersion: Bool
+    incrementVersion _: Bool
   ) {
-    let newVersion = CatbirdMLSCore.MLSNotificationCoordinator.publishMutation(
+    _ = CatbirdMLSCore.MLSNotificationCoordinator.publishMutation(
       userDID: userDid,
       source: source,
       decryptionOwner: .appNotification,
-      incrementVersion: incrementVersion
+      incrementVersion: false,
+      postStateChanged: false
     )
-    if let versionAfter = newVersion {
-      notificationLogger.info(
-        "📡 [FG] Signaled inactive-account MLS mutation (source=\(source), decryption_owner=app_notification, version_after=\(versionAfter))"
-      )
-    } else {
-      notificationLogger.info(
-        "📡 [FG] Signaled inactive-account MLS mutation (source=\(source), decryption_owner=app_notification, version_after=unchanged)"
-      )
-    }
+    notificationLogger.info(
+      "📡 [FG] Signaled inactive-account MLS mutation (source=\(source), decryption_owner=app_notification)"
+    )
   }
 
   // MARK: - Group Join Helpers


### PR DESCRIPTION
## Summary

`signalInactiveAccountStateMutation` was posting the cross-process
`stateChanged` Darwin notification and bumping the cross-process MLS
disk version on every main-app foreground decode (notifications routed
to inactive accounts). The main app received its own broadcast via the
`MLSStateChangeNotifier` observer registered in `AppState.initialize`
and triggered a full `MLSCoreContext` teardown + reload from disk on
every send/receive.

## Observed log pattern (before fix)

```
✅ encryptMessage → version 49141 → 49142
📢 [MLS State] Posted Darwin notification: stateChanged
📥 [MLS State] Received Darwin notification: stateChanged from NSE
🔄 Debounce elapsed - invoking state reload
🔄 [AppState] Reloading MLS state from disk (catching up with NSE)
🔄 [CONTEXT] Stale context detected: disk=49142, memory=49141
Creating new MLS context for user: …
```

## Removed-post call sites in this PR

- `Catbird/Features/Notifications/Services/NotificationManager.swift:2722` — `publishMutation` now passes `incrementVersion: false, postStateChanged: false` regardless of the caller's `incrementVersion` argument

## Kept-post call sites (NSE — load-bearing direction)

- `NotificationServiceExtension/NotificationService.swift:528` — NSE post-decrypt `publishMutation` (NSE process is the legitimate cross-process producer)
- `NotificationServiceExtension/NotificationService.swift:856` — NSE close-sequence `postStateChanged()`
- Receiver side in `Catbird/Core/State/AppState.swift:2349` (`MLSNotificationCoordinator.configureAppObservers`) is unchanged — no self-guard added (option 2). With the post sites eliminated this is no longer reachable from main-app mutations.

## Categorization rule

The cross-process MLS state version and the `stateChanged` Darwin
notification are **one-directional NSE→app signals**. The main app
posting them on its own mutations is a self-loop. Use
`MLSNotificationCoordinator.publishMutation(..., incrementVersion: false, postStateChanged: false)`
for audit-only logging on the main-app side.

## Companion PR

CatbirdMLSCore side: https://github.com/joshlacal/CatbirdMLSCore/pull/2

The CatbirdMLSCore PR fixes the symmetric problem in five
`MLSConversationManager+Messaging.swift` call sites (encrypt, decrypt,
processMessage, atomic-commit, sequence-commit). This PR is incomplete
without that one — the `MLSStateChangeNotifier`/`MLSStateVersionManager`
implementation lives in CatbirdMLSCore.

## Test plan

- [x] `xcodebuild -project Catbird.xcodeproj -scheme Catbird -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build` — succeeded on iOS 26.4
- [ ] Manual: send 5 messages in active account → expect zero
      `[CONTEXT] Stale context detected` log lines and zero
      `Creating new MLS context for user` reloads
- [ ] Manual: receive a real APNS push routed through NSE → expect
      exactly one main app reload after the 100ms debounce
- [ ] Manual: foreground notification routed to **inactive** account
      → verify the audit log still emits but no Darwin post / version
      bump appears in `Console.app` filtered by subsystem
      `blue.catbird.mls`

🤖 Generated with [Claude Code](https://claude.com/claude-code)