### PR TITLE
CLIENT H — refresh MLS DB pool before captured-database reads

### DIFF
--- a/Catbird/Features/MLSChat/MLSConversationDetailView.swift
+++ b/Catbird/Features/MLSChat/MLSConversationDetailView.swift
@@ -3088,6 +3088,9 @@ struct MLSConversationDetailView: View {
       return
     }
 
+    // 🔒 [CLIENT H] Refresh pool before capture; closeAndDrain during
+    // account switch can invalidate manager.database mid-call.
+    try? await manager.refreshDatabaseIfNeeded()
     let storage = manager.storage
     let database = manager.database
 

--- a/Catbird/Features/MLSChat/MLSConversationListView.swift
+++ b/Catbird/Features/MLSChat/MLSConversationListView.swift
@@ -1074,9 +1074,13 @@ struct MLSConversationListView: View {
     private func loadRecentMemberChanges() async {
         guard let manager = await appState.getMLSConversationManager(timeout: 5.0)
                else { return }
+        // 🔒 [CLIENT H] Refresh the pool before capturing — closeAndDrain
+        // during account switch can invalidate `manager.database` between
+        // here and the read below, surfacing as "Connection is closed".
+        try? await manager.refreshDatabaseIfNeeded()
         let storage = manager.storage
         let database = manager.database
-        
+
         do {
             let recentEvents = try await storage.fetchRecentMembershipChanges(
                 currentUserDID: appState.userDID,


### PR DESCRIPTION
## Summary

Catbird-side portion of CLIENT H. Two View sites (`MLSConversationListView.loadRecentMemberChanges`, `MLSConversationDetailView.clearMembershipChangeBadge`) read `manager.database` directly. If account-switch `closeAndDrain` fires after we resolve the manager but before we hit the read, the captured handle surfaces as **"Connection is closed"** (observed for conversation `3153f1a2` in the production log).

Fix: call `manager.refreshDatabaseIfNeeded()` immediately before capturing. The helper transparently reconnects via `databaseManager` when the pool has been drained.

Pairs with `joshlacal/CatbirdMLSCore#feature/post-deploy-fixes-2026-04-28` which contains CLIENT D/E/F/G plus the in-package portion of H (the `handleEpochUpdate` fire-and-forget Task fix).

## Test plan

- [ ] Build clean (verified locally on iPhone 17 Pro sim, BUILD SUCCEEDED)
- [ ] Account-switch during active group detail view; previously crashed with "Connection is closed", now recovers via `refreshDatabaseIfNeeded`
- [ ] Account-switch while ConversationListView is loading recent member changes; should refresh pool transparently

🤖 Generated with [Claude Code](https://claude.com/claude-code)