### PR TITLE
security: migrate gateway OAuth to one-time exchange codes

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,15 +33,14 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --model claude-sonnet-4-6
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
-          
           # Direct prompt for automated review (no @claude mention needed)
-          direct_prompt: |
+          prompt: |
             Please review this pull request and provide feedback on:
             - Code quality and best practices
             - Potential bugs or issues
@@ -75,4 +74,3 @@ jobs:
           # if: |
           #   !contains(github.event.pull_request.title, '[skip-review]') &&
           #   !contains(github.event.pull_request.title, '[WIP]')
-

--- a/Catbird/App/CatbirdApp.swift
+++ b/Catbird/App/CatbirdApp.swift
@@ -1095,10 +1095,12 @@ NavigationFontConfig.applyEarlyNavigationBarAppearance()
       }
       .catalystPlainButtons()
       .onOpenURL { url in
-          logger.info("Received URL: \(url.absoluteString)")
+          logger.info(
+            "Received URL for scheme=\(url.scheme ?? "none", privacy: .public) host=\(url.host ?? "none", privacy: .public) path=\(url.path, privacy: .public)"
+          )
 
           // Check for gateway BFF callback (Universal Link from catbird.blue)
-          // Gateway redirects to: https://catbird.blue/oauth/callback#session_id=<uuid>
+          // Gateway redirects with a one-time exchange code in the query.
           if url.host == "catbird.blue" && url.path == "/oauth/callback" {
             logger.info("Gateway OAuth callback detected")
             Task {

--- a/Catbird/Core/Networking/GatewayOAuthExchange.swift
+++ b/Catbird/Core/Networking/GatewayOAuthExchange.swift
@@ -1,0 +1,349 @@
+import Foundation
+import Security
+
+enum GatewayOAuthExchangeError: Error, Equatable {
+  case configuration
+  case flowInProgress
+  case unauthorized
+}
+
+/// Owns the in-memory proof that binds a native browser login to its callback.
+/// A pending nonce is removed before callback validation or network I/O so every
+/// callback attempt is single-use locally, including malformed attempts.
+actor GatewayOAuthExchange {
+  typealias Sender = @Sendable (URLRequest) async throws -> (Data, URLResponse)
+
+  static let maximumResponseBytes = 8 * 1024
+
+  private let gatewayURL: URL
+  private let callbackURL: URL
+  private let callbackOrigin: String
+  private let uptime: @Sendable () -> TimeInterval
+  private let send: Sender
+  private var pending: PendingLogin?
+
+  init(gatewayURL: URL, callbackURL: URL) {
+    let transport = GatewayOAuthExchangeTransport(maximumBytes: Self.maximumResponseBytes)
+    self.gatewayURL = gatewayURL
+    self.callbackURL = callbackURL
+    self.callbackOrigin = Self.origin(of: callbackURL) ?? ""
+    self.uptime = { ProcessInfo.processInfo.systemUptime }
+    self.send = { request in try await transport.send(request) }
+  }
+
+  init(
+    gatewayURL: URL,
+    callbackURL: URL,
+    uptime: @escaping @Sendable () -> TimeInterval = { ProcessInfo.processInfo.systemUptime },
+    send: @escaping Sender
+  ) {
+    self.gatewayURL = gatewayURL
+    self.callbackURL = callbackURL
+    self.callbackOrigin = Self.origin(of: callbackURL) ?? ""
+    self.uptime = uptime
+    self.send = send
+  }
+
+  func prepareLogin(_ loginURL: URL) throws -> URL {
+    if let pending, uptime() - pending.createdAt <= 60 {
+      throw GatewayOAuthExchangeError.flowInProgress
+    }
+    pending = nil
+
+    guard Self.isHTTPSOrigin(gatewayURL),
+      Self.isHTTPSOrigin(callbackURL),
+      callbackURL.user == nil,
+      callbackURL.password == nil,
+      callbackURL.query == nil,
+      callbackURL.fragment == nil,
+      !callbackOrigin.isEmpty,
+      Self.origin(of: loginURL) == Self.origin(of: gatewayURL),
+      var components = URLComponents(url: loginURL, resolvingAgainstBaseURL: false)
+    else {
+      pending = nil
+      throw GatewayOAuthExchangeError.configuration
+    }
+
+    let nonce = try Self.randomNonce()
+    var queryItems = (components.queryItems ?? []).filter {
+      $0.name != "browser_nonce" && $0.name != "redirect_to"
+    }
+    queryItems.append(URLQueryItem(name: "browser_nonce", value: nonce))
+    queryItems.append(URLQueryItem(name: "redirect_to", value: callbackURL.absoluteString))
+    components.queryItems = queryItems
+
+    guard let boundURL = components.url else {
+      pending = nil
+      throw GatewayOAuthExchangeError.configuration
+    }
+    pending = PendingLogin(nonce: nonce, createdAt: uptime())
+    return boundURL
+  }
+
+  func redeem(_ callback: URL) async throws -> String {
+    guard let pending else {
+      throw GatewayOAuthExchangeError.unauthorized
+    }
+    self.pending = nil
+
+    guard uptime() - pending.createdAt <= 60 else {
+      throw GatewayOAuthExchangeError.unauthorized
+    }
+
+    guard let code = Self.validatedCode(from: callback, expected: callbackURL) else {
+      throw GatewayOAuthExchangeError.unauthorized
+    }
+
+    var request = URLRequest(url: gatewayURL.appendingPathComponent("auth/exchange"))
+    request.httpMethod = "POST"
+    request.timeoutInterval = 15
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    request.setValue(callbackOrigin, forHTTPHeaderField: "Origin")
+    request.httpBody = try? JSONEncoder().encode(
+      ExchangeRequest(code: code, browserNonce: pending.nonce))
+
+    guard request.httpBody != nil else {
+      throw GatewayOAuthExchangeError.unauthorized
+    }
+
+    do {
+      let (data, response) = try await send(request)
+      guard let http = response as? HTTPURLResponse,
+        (200..<300).contains(http.statusCode),
+        data.count <= Self.maximumResponseBytes,
+        http.value(forHTTPHeaderField: "Content-Type")?.lowercased()
+          .hasPrefix("application/json") == true,
+        let payload = try? JSONDecoder().decode(ExchangeResponse.self, from: data),
+        Self.isValidSessionID(payload.sessionID)
+      else {
+        throw GatewayOAuthExchangeError.unauthorized
+      }
+      return payload.sessionID
+    } catch is GatewayOAuthExchangeError {
+      throw GatewayOAuthExchangeError.unauthorized
+    } catch {
+      throw GatewayOAuthExchangeError.unauthorized
+    }
+  }
+
+  func cancelPendingLogin() {
+    pending = nil
+  }
+
+  private static func randomNonce() throws -> String {
+    var bytes = [UInt8](repeating: 0, count: 32)
+    guard SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes) == errSecSuccess else {
+      throw GatewayOAuthExchangeError.configuration
+    }
+    return Data(bytes).base64EncodedString()
+      .replacingOccurrences(of: "+", with: "-")
+      .replacingOccurrences(of: "/", with: "_")
+      .replacingOccurrences(of: "=", with: "")
+  }
+
+  private static func validatedCode(from callback: URL, expected: URL) -> String? {
+    guard callback.scheme?.lowercased() == expected.scheme?.lowercased(),
+      callback.host?.lowercased() == expected.host?.lowercased(),
+      effectivePort(of: callback) == effectivePort(of: expected),
+      callback.path == expected.path,
+      callback.user == nil,
+      callback.password == nil,
+      callback.fragment == nil,
+      let components = URLComponents(url: callback, resolvingAgainstBaseURL: false),
+      let queryItems = components.queryItems,
+      queryItems.count == 1,
+      queryItems[0].name == "code",
+      let code = queryItems[0].value,
+      code.count == 43,
+      code.utf8.allSatisfy({ byte in
+        (65...90).contains(byte) || (97...122).contains(byte) || (48...57).contains(byte)
+          || byte == 45 || byte == 95
+      })
+    else {
+      return nil
+    }
+    return code
+  }
+
+  private static func effectivePort(of url: URL) -> Int? {
+    if let port = url.port { return port }
+    return url.scheme?.lowercased() == "https" ? 443 : nil
+  }
+
+  private static func isValidSessionID(_ sessionID: String) -> Bool {
+    !sessionID.isEmpty && sessionID.utf8.count <= 512
+      && sessionID.utf8.allSatisfy { $0 >= 0x21 && $0 <= 0x7e }
+  }
+
+  private static func isHTTPSOrigin(_ url: URL) -> Bool {
+    url.scheme?.lowercased() == "https" && url.host != nil && url.user == nil && url.password == nil
+  }
+
+  private static func origin(of url: URL) -> String? {
+    guard isHTTPSOrigin(url), let host = url.host?.lowercased() else { return nil }
+    if let port = url.port, port != 443 {
+      return "https://\(host):\(port)"
+    }
+    return "https://\(host)"
+  }
+
+  private struct PendingLogin {
+    let nonce: String
+    let createdAt: TimeInterval
+  }
+}
+
+final class GatewayOAuthExchangeTransport: @unchecked Sendable {
+  static let redirectTarget: URLRequest? = nil
+
+  private let delegate: GatewayOAuthExchangeSessionDelegate
+  private let session: URLSession
+  var hasInitializedSession: Bool { true }
+
+  init(maximumBytes: Int) {
+    let delegate = GatewayOAuthExchangeSessionDelegate(maximumBytes: maximumBytes)
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.httpShouldSetCookies = false
+    configuration.httpCookieAcceptPolicy = .never
+    configuration.urlCache = nil
+    configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+    self.delegate = delegate
+    self.session = URLSession(configuration: configuration, delegate: delegate, delegateQueue: nil)
+  }
+
+  func send(_ request: URLRequest) async throws -> (Data, URLResponse) {
+    try await withCheckedThrowingContinuation { continuation in
+      let task = session.dataTask(with: request)
+      delegate.register(task: task, continuation: continuation)
+      task.resume()
+    }
+  }
+
+  static func responseDisposition(hasPendingRequest: Bool) -> URLSession.ResponseDisposition {
+    hasPendingRequest ? .allow : .cancel
+  }
+
+  static func append(_ chunk: Data, to data: inout Data, maximumBytes: Int) throws {
+    guard data.count <= maximumBytes, chunk.count <= maximumBytes - data.count else {
+      throw GatewayOAuthExchangeError.unauthorized
+    }
+    data.append(chunk)
+  }
+}
+
+private final class GatewayOAuthExchangeSessionDelegate: NSObject, URLSessionDataDelegate,
+  @unchecked Sendable
+{
+  private struct PendingRequest {
+    let continuation: CheckedContinuation<(Data, URLResponse), Error>
+    var data = Data()
+    var response: URLResponse?
+  }
+
+  private let maximumBytes: Int
+  private let lock = NSLock()
+  private var requests: [Int: PendingRequest] = [:]
+
+  init(maximumBytes: Int) {
+    self.maximumBytes = maximumBytes
+  }
+
+  func register(
+    task: URLSessionTask,
+    continuation: CheckedContinuation<(Data, URLResponse), Error>
+  ) {
+    lock.withLock {
+      requests[task.taskIdentifier] = PendingRequest(continuation: continuation)
+    }
+  }
+
+  func urlSession(
+    _ session: URLSession,
+    task: URLSessionTask,
+    willPerformHTTPRedirection response: HTTPURLResponse,
+    newRequest request: URLRequest,
+    completionHandler: @escaping (URLRequest?) -> Void
+  ) {
+    completionHandler(GatewayOAuthExchangeTransport.redirectTarget)
+  }
+
+  func urlSession(
+    _ session: URLSession,
+    dataTask: URLSessionDataTask,
+    didReceive response: URLResponse,
+    completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+  ) {
+    var rejected: PendingRequest?
+    let hasPendingRequest = lock.withLock {
+      guard var pending = requests[dataTask.taskIdentifier] else { return false }
+      if response.expectedContentLength > maximumBytes {
+        rejected = requests.removeValue(forKey: dataTask.taskIdentifier)
+      } else {
+        pending.response = response
+        requests[dataTask.taskIdentifier] = pending
+      }
+      return true
+    }
+    if let rejected {
+      rejected.continuation.resume(throwing: GatewayOAuthExchangeError.unauthorized)
+      completionHandler(.cancel)
+    } else {
+      completionHandler(
+        GatewayOAuthExchangeTransport.responseDisposition(
+          hasPendingRequest: hasPendingRequest))
+    }
+  }
+
+  func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+    var rejected: PendingRequest?
+    lock.withLock {
+      guard var pending = requests[dataTask.taskIdentifier] else { return }
+      do {
+        try GatewayOAuthExchangeTransport.append(
+          data, to: &pending.data, maximumBytes: maximumBytes)
+        requests[dataTask.taskIdentifier] = pending
+      } catch {
+        rejected = requests.removeValue(forKey: dataTask.taskIdentifier)
+      }
+    }
+    if let rejected {
+      dataTask.cancel()
+      rejected.continuation.resume(throwing: GatewayOAuthExchangeError.unauthorized)
+    }
+  }
+
+  func urlSession(
+    _ session: URLSession,
+    task: URLSessionTask,
+    didCompleteWithError error: Error?
+  ) {
+    let pending = lock.withLock { requests.removeValue(forKey: task.taskIdentifier) }
+    guard let pending else { return }
+    if let error {
+      pending.continuation.resume(throwing: error)
+    } else if let response = pending.response {
+      pending.continuation.resume(returning: (pending.data, response))
+    } else {
+      pending.continuation.resume(throwing: GatewayOAuthExchangeError.unauthorized)
+    }
+  }
+}
+
+private struct ExchangeRequest: Encodable {
+  let code: String
+  let browserNonce: String
+
+  enum CodingKeys: String, CodingKey {
+    case code
+    case browserNonce = "browser_nonce"
+  }
+}
+
+private struct ExchangeResponse: Decodable {
+  let sessionID: String
+
+  enum CodingKeys: String, CodingKey {
+    case sessionID = "session_id"
+  }
+}

--- a/Catbird/Core/Networking/URLHandler.swift
+++ b/Catbird/Core/Networking/URLHandler.swift
@@ -79,7 +79,9 @@ final class URLHandler {
     func handle(_ url: URL, tabIndex: Int? = nil) -> OpenURLAction.Result {
         // Use the provided tab index or get the current tab from the navigation manager
         targetTabIndex = tabIndex ?? appState?.navigationManager.currentTabIndex
-        logger.info("📲 URLHandler processing URL: \(url.absoluteString, privacy: .sensitive), target tab: \(self.targetTabIndex ?? -1)")
+        logger.info(
+          "📲 URLHandler processing scheme=\(url.scheme ?? "none", privacy: .public) host=\(url.host ?? "none", privacy: .public) path=\(url.path, privacy: .public), target tab: \(self.targetTabIndex ?? -1)"
+        )
         let urlString = url.absoluteString
         
         // First check if the URL matches our OAuth callback path
@@ -362,7 +364,9 @@ final class URLHandler {
     func handleURL(_ url: URL, tabIndex: Int? = nil) async -> Bool {
         // Use the provided tab index or get the current tab from the navigation manager
         targetTabIndex = tabIndex ?? appState?.navigationManager.currentTabIndex
-        logger.info("📲 URLHandler simple processing URL: \(url.absoluteString, privacy: .sensitive), target tab: \(self.targetTabIndex ?? -1)")
+        logger.info(
+          "📲 URLHandler simple processing scheme=\(url.scheme ?? "none", privacy: .public) host=\(url.host ?? "none", privacy: .public) path=\(url.path, privacy: .public), target tab: \(self.targetTabIndex ?? -1)"
+        )
         let urlString = url.absoluteString
         
         // OAuth callback handling

--- a/Catbird/Core/State/AppState.swift
+++ b/Catbird/Core/State/AppState.swift
@@ -1189,7 +1189,7 @@ final class AppState {
     @MainActor
     func handleOAuthCallback(_ url: URL) async throws {
         logger.info("AppState handling OAuth callback")
-        try await AppStateManager.shared.authentication.handleCallback(url)
+        try await AppStateManager.shared.authentication.handleGatewayCallback(url)
     }
 
     /// Force updates the authentication state (used in rare cases where state updates aren't properly propagated)

--- a/Catbird/Core/State/AuthManager.swift
+++ b/Catbird/Core/State/AuthManager.swift
@@ -124,6 +124,8 @@ enum AuthProgress: Equatable, Sendable {
 /// Handles all authentication-related operations with a clean state machine approach
 @Observable
 final class AuthenticationManager: AuthProgressDelegate {
+  static let gatewayURL = URL(string: "https://api.catbird.blue")!
+
   // MARK: - Properties
 
   private let logger = Logger(subsystem: "blue.catbird", category: "Authentication")
@@ -191,6 +193,12 @@ final class AuthenticationManager: AuthProgressDelegate {
     clientId: "https://catbird.blue/oauth-client-metadata.json",
     redirectUri: "https://catbird.blue/oauth/callback",
     scope: "atproto transition:generic transition:chat.bsky"
+  )
+
+  @ObservationIgnored
+  private let gatewayOAuthExchange = GatewayOAuthExchange(
+    gatewayURL: AuthenticationManager.gatewayURL,
+    callbackURL: URL(string: "https://catbird.blue/oauth/callback")!
   )
 
   // MARK: - Debounce Flag for Auth Expiration
@@ -410,7 +418,7 @@ final class AuthenticationManager: AuthProgressDelegate {
             oauthConfig: oauthCfg,
             namespace: "blue.catbird",
             authMode: .gateway,
-            gatewayURL: URL(string: "https://api.catbird.blue")!,
+            gatewayURL: AuthenticationManager.gatewayURL,
 //            gatewayURL: URL(string: "https://dev-api.catbird.blue")!,
             userAgent: "Catbird/1.0",
             bskyAppViewDID: appViewDID,
@@ -424,7 +432,7 @@ final class AuthenticationManager: AuthProgressDelegate {
           oauthConfig: oauthCfg,
           namespace: "blue.catbird",
           authMode: .gateway,
-          gatewayURL: URL(string: "https://api.catbird.blue")!,
+          gatewayURL: AuthenticationManager.gatewayURL,
           userAgent: "Catbird/1.0",
           bskyAppViewDID: appViewDID,
           bskyChatDID: chatDID,
@@ -715,7 +723,7 @@ final class AuthenticationManager: AuthProgressDelegate {
         oauthConfig: oauthConfig,
         namespace: "blue.catbird",
         authMode: .gateway,
-        gatewayURL: URL(string: "https://api.catbird.blue")!,
+        gatewayURL: AuthenticationManager.gatewayURL,
 //        gatewayURL: URL(string: "https://dev-api.catbird.blue")!,
         userAgent: "Catbird/1.0",
         bskyAppViewDID: customAppViewDID,
@@ -728,7 +736,7 @@ final class AuthenticationManager: AuthProgressDelegate {
           oauthConfig: oauthConfig,
           namespace: "blue.catbird",
           authMode: .gateway,
-          gatewayURL: URL(string: "https://api.catbird.blue")!,
+          gatewayURL: AuthenticationManager.gatewayURL,
           userAgent: "Catbird/1.0",
           bskyAppViewDID: customAppViewDID,
           bskyChatDID: customChatDID,
@@ -781,9 +789,10 @@ final class AuthenticationManager: AuthProgressDelegate {
             )
           }
 
-          logger.info("OAuth URL generated successfully: \(authURL.absoluteString)")
+          let boundAuthURL = try await gatewayOAuthExchange.prepareLogin(authURL)
+          logger.info("OAuth URL generated successfully")
           await self.updateState(.authenticating(progress: .openingBrowser))
-          return authURL
+          return boundAuthURL
         } catch {
           lastError = error
           self.logger.warning("OAuth flow attempt \(attempt) failed: \(error.localizedDescription)")
@@ -978,7 +987,7 @@ final class AuthenticationManager: AuthProgressDelegate {
   /// Handle the OAuth callback after web authentication with timeout support
   @MainActor
   func handleCallback(_ url: URL) async throws {
-    logger.info("🔗 [CALLBACK] Processing OAuth callback: \(url.absoluteString)")
+    logger.info("🔗 [CALLBACK] Processing OAuth callback")
     logger.debug("🔗 [CALLBACK] URL scheme: \(url.scheme ?? "none"), host: \(url.host ?? "none")")
     logger.debug("🔗 [CALLBACK] Current state: \(String(describing: self.state))")
     updateState(.authenticating(progress: .exchangingTokens))
@@ -1098,11 +1107,10 @@ final class AuthenticationManager: AuthProgressDelegate {
     }
   }
 
-  /// Handle OAuth callback from gateway BFF (session_id in URL fragment)
-  /// The gateway redirects to: https://catbird.blue/oauth/callback#session_id=<uuid>
+  /// Handle a gateway callback by atomically exchanging its one-time code.
   @MainActor
   func handleGatewayCallback(_ url: URL) async throws {
-    logger.info("🔗 [GATEWAY] Processing gateway callback: \(url.absoluteString)")
+    logger.info("🔗 [GATEWAY] Processing gateway callback")
     updateState(.authenticating(progress: .exchangingTokens))
 
     // Ensure client exists (cold start scenario)
@@ -1118,26 +1126,25 @@ final class AuthenticationManager: AuthProgressDelegate {
       }
     }
 
-    // Parse session_id from URL fragment
-    guard let fragment = url.fragment,
-      let sessionId = parseGatewaySessionId(from: fragment)
-    else {
-      logger.error("❌ [GATEWAY] Invalid callback URL - missing session_id in fragment")
-      let error = AuthError.invalidCallbackURL
-      updateState(.error(message: error.localizedDescription))
-      throw error
-    }
-
-    logger.debug("✅ [GATEWAY] Parsed session_id from fragment")
-
     do {
       updateState(.authenticating(progress: .creatingSession))
 
-      // Delegate to Petrel's gateway callback handler (which fetches /auth/session)
+      let sessionID = try await gatewayOAuthExchange.redeem(url)
+      var internalCallback = URLComponents()
+      internalCallback.scheme = "https"
+      internalCallback.host = "catbird.blue"
+      internalCallback.path = "/oauth/callback"
+      internalCallback.fragment = "session_id=\(sessionID)"
+      guard let sessionCallbackURL = internalCallback.url else {
+        throw AuthError.invalidCallbackURL
+      }
+
+      // Petrel consumes this in-memory URL to persist the exchanged gateway session.
+      // It is never emitted externally or logged.
       guard let activeClient = client else {
         throw AuthError.clientNotInitialized
       }
-      try await activeClient.handleOAuthCallback(url: url)
+      try await activeClient.handleOAuthCallback(url: sessionCallbackURL)
 
       updateState(.authenticating(progress: .finalizing))
 
@@ -1181,13 +1188,9 @@ final class AuthenticationManager: AuthProgressDelegate {
     }
   }
 
-  /// Parse session_id from URL fragment (e.g., "session_id=abc123&foo=bar")
-  private func parseGatewaySessionId(from fragment: String) -> String? {
-    let pairs = fragment.split(separator: "&").map { $0.split(separator: "=", maxSplits: 1) }
-    for pair in pairs where pair.count == 2 && pair[0] == "session_id" {
-      return String(pair[1])
-    }
-    return nil
+  @MainActor
+  func cancelGatewayOAuthFlow() async {
+    await gatewayOAuthExchange.cancelPendingLogin()
   }
 
   /// Logout the current user
@@ -1555,7 +1558,7 @@ final class AuthenticationManager: AuthProgressDelegate {
       oauthConfig: oauthConfig,
       namespace: "blue.catbird",
       authMode: .gateway,
-      gatewayURL: URL(string: "https://api.catbird.blue")!,
+      gatewayURL: AuthenticationManager.gatewayURL,
 //      gatewayURL: URL(string: "https://dev-api.catbird.blue")!,
       userAgent: "Catbird/1.0",
       bskyAppViewDID: customAppViewDID,
@@ -1567,7 +1570,7 @@ final class AuthenticationManager: AuthProgressDelegate {
         oauthConfig: oauthConfig,
         namespace: "blue.catbird",
         authMode: .gateway,
-        gatewayURL: URL(string: "https://api.catbird.blue")!,
+        gatewayURL: AuthenticationManager.gatewayURL,
         userAgent: "Catbird/1.0",
         bskyAppViewDID: customAppViewDID,
         bskyChatDID: customChatDID,
@@ -1871,10 +1874,11 @@ final class AuthenticationManager: AuthProgressDelegate {
       let authURL = try await withTimeout(timeout: networkTimeout) {
         try await client.startOAuthFlow(identifier: handle)
       }
-      self.logger.debug("OAuth URL generated for new account: \(authURL)")
+      let boundAuthURL = try await gatewayOAuthExchange.prepareLogin(authURL)
+      self.logger.debug("OAuth URL generated for new account")
 
       updateState(.authenticating(progress: .openingBrowser))
-      return authURL
+      return boundAuthURL
     } catch {
       let finalError: AuthError
       if error is CancellationError {
@@ -1891,6 +1895,16 @@ final class AuthenticationManager: AuthProgressDelegate {
       updateState(.error(message: "Failed to add account: \(finalError.localizedDescription)"))
       throw finalError
     }
+  }
+
+  /// Start gateway account creation with the same native nonce binding as login.
+  @MainActor
+  func startSignUp(pdsURL: URL) async throws -> URL {
+    guard let client else {
+      throw AuthError.clientNotInitialized
+    }
+    let authURL = try await client.startSignUpFlow(pdsURL: pdsURL)
+    return try await gatewayOAuthExchange.prepareLogin(authURL)
   }
 
   /// Get current active account info

--- a/Catbird/Features/Auth/Views/AccountSwitcherView.swift
+++ b/Catbird/Features/Auth/Views/AccountSwitcherView.swift
@@ -531,7 +531,7 @@ struct AccountSwitcherView: View {
             // in Petrel's account list - it just needs a fresh OAuth session
             logger.debug("🔐 [SWITCH] Calling authentication.login(handle: \(handle)) for reauthentication")
             let authURL = try await appStateManager.authentication.login(handle: handle)
-            logger.info("✅ [SWITCH] Got OAuth URL for reauthentication: \(authURL.absoluteString)")
+            logger.info("✅ [SWITCH] Got OAuth URL for reauthentication")
 
             // Get the AppState if it exists
             guard let currentAppState = appStateManager.lifecycle.appState else {
@@ -650,7 +650,7 @@ struct AccountSwitcherView: View {
     do {
       // Get auth URL
       let authURL = try await appStateManager.authentication.addAccount(handle: cleanHandle)
-      logger.debug("Auth URL for new account: \(authURL.absoluteString)")
+      logger.debug("Auth URL generated for new account")
 
       // Open web authentication session with timeout
       do {
@@ -692,10 +692,10 @@ struct AccountSwitcherView: View {
         }
 
         logger.info("Authentication session completed successfully")
-        logger.debug("Callback URL: \(callbackURL.absoluteString)")
+        logger.debug("OAuth callback received")
 
         // Process callback
-        try await appStateManager.authentication.handleCallback(callbackURL)
+        try await appStateManager.authentication.handleGatewayCallback(callbackURL)
 
         // Success - close add account sheet
         isAddingAccount = false
@@ -703,6 +703,7 @@ struct AccountSwitcherView: View {
         // Refresh account list
         await loadAccounts()
       } catch _ as ASWebAuthenticationSessionError {
+        await appStateManager.authentication.cancelGatewayOAuthFlow()
         // User cancelled authentication
         logger.notice("Authentication was cancelled by user")
         authenticationCancelled = true
@@ -735,7 +736,7 @@ struct AccountSwitcherView: View {
   private func handleReauthentication(_ request: AppState.ReauthenticationRequest) async {
     logger.info("🔐 [REAUTH] Starting reauthentication for handle: \(request.handle)")
     logger.info("🔐 [REAUTH] DID: \(request.did)")
-    logger.info("🔐 [REAUTH] Auth URL: \(request.authURL.absoluteString)")
+    logger.info("🔐 [REAUTH] Auth URL is ready")
     logger.debug("🔐 [REAUTH] Auth URL scheme: \(request.authURL.scheme ?? "no scheme")")
     logger.debug("🔐 [REAUTH] Auth URL host: \(request.authURL.host ?? "no host")")
 
@@ -771,7 +772,7 @@ struct AccountSwitcherView: View {
               preferredBrowserSession: .shared,
               additionalHeaderFields: [:]
             )
-            self.logger.info("✅ [REAUTH] authenticate() returned with callback URL: \(result.absoluteString)")
+            self.logger.info("✅ [REAUTH] authenticate() returned an OAuth callback")
             return result
           } else {
             self.logger.info("🌐 [REAUTH] Using legacy authenticate API with callbackURLScheme")
@@ -782,7 +783,7 @@ struct AccountSwitcherView: View {
               callbackURLScheme: "catbird",
               preferredBrowserSession: .shared
             )
-            self.logger.info("✅ [REAUTH] authenticate() returned with callback URL: \(result.absoluteString)")
+            self.logger.info("✅ [REAUTH] authenticate() returned an OAuth callback")
             return result
           }
         }
@@ -808,13 +809,13 @@ struct AccountSwitcherView: View {
       }
 
       logger.info("✅ [REAUTH] Reauthentication session completed successfully")
-      logger.info("🔗 [REAUTH] Callback URL: \(callbackURL.absoluteString)")
+      logger.info("🔗 [REAUTH] OAuth callback received")
       logger.debug("🔗 [REAUTH] Callback scheme: \(callbackURL.scheme ?? "none")")
       logger.debug("🔗 [REAUTH] Callback host: \(callbackURL.host ?? "none")")
 
       // Process callback
       logger.info("🔄 [REAUTH] Processing callback with authManager.handleCallback()")
-      try await appStateManager.authentication.handleCallback(callbackURL)
+      try await appStateManager.authentication.handleGatewayCallback(callbackURL)
       logger.info("✅ [REAUTH] Callback processed successfully")
       
       // Clear any previous cancelled/error state since we succeeded
@@ -841,6 +842,7 @@ struct AccountSwitcherView: View {
       logger.debug("🔄 [REAUTH] Setting isLoading = false")
       isLoading = false
     } catch let error as ASWebAuthenticationSessionError {
+      await appStateManager.authentication.cancelGatewayOAuthFlow()
       // User cancelled reauthentication
       logger.notice("🚫 [REAUTH] Reauthentication was cancelled by user")
       logger.debug("🚫 [REAUTH] ASWebAuthenticationSessionError code: \(error.code.rawValue)")

--- a/Catbird/Features/Auth/Views/LoginView.swift
+++ b/Catbird/Features/Auth/Views/LoginView.swift
@@ -1154,7 +1154,7 @@ struct LoginView: View {
                     loginProgress = .processingCallback
 
                     // Process callback
-                    try await appStateManager.authentication.handleCallback(callbackURL)
+                    try await appStateManager.authentication.handleGatewayCallback(callbackURL)
 
                     // Check for cancellation after callback processing
                     try Task.checkCancellation()
@@ -1165,6 +1165,7 @@ struct LoginView: View {
                     // Success is handled via onChange of authState
 
                 } catch let authSessionError as ASWebAuthenticationSessionError {
+                    await appStateManager.authentication.cancelGatewayOAuthFlow()
                     // User cancelled authentication
                     logger.notice("Authentication was cancelled by user: \(authSessionError._nsError.localizedDescription)")
                     // Only set authenticationCancelled for explicit user cancellation
@@ -1287,7 +1288,7 @@ struct LoginView: View {
                     loginProgress = .processingCallback
 
                     // Process callback
-                    try await appStateManager.authentication.handleCallback(callbackURL)
+                    try await appStateManager.authentication.handleGatewayCallback(callbackURL)
 
                     // Check for cancellation after callback processing
                     try Task.checkCancellation()
@@ -1298,6 +1299,7 @@ struct LoginView: View {
                     // Success is handled via onChange of authState
 
                 } catch let authSessionError as ASWebAuthenticationSessionError {
+                    await appStateManager.authentication.cancelGatewayOAuthFlow()
                     // User cancelled authentication
                     logger.notice("Re-authentication was cancelled by user: \(authSessionError._nsError.localizedDescription)")
                     // Only set authenticationCancelled for explicit user cancellation
@@ -1367,18 +1369,10 @@ struct LoginView: View {
         authenticationTask = Task { @MainActor in
             do {
                 // Get auth URL for signup
-                let authURL = try await appStateManager.authentication.client?.startSignUpFlow(pdsURL: pdsURL)
+                let authURL = try await appStateManager.authentication.startSignUp(pdsURL: pdsURL)
 
                 // Check for cancellation after getting auth URL
                 try Task.checkCancellation()
-
-                guard let authURL else {
-                    logger.error("Failed to get auth URL for signup")
-                    error = "Failed to get authentication URL"
-                    isLoggingIn = false
-                    showTimeoutCountdown = false
-                    return
-                }
 
                 // Open web authentication session
                 do {
@@ -1394,7 +1388,7 @@ struct LoginView: View {
                     logger.info("Signup authentication session completed successfully")
 
                     // Process callback
-                    try await appStateManager.authentication.handleCallback(callbackURL)
+                    try await appStateManager.authentication.handleGatewayCallback(callbackURL)
 
                     // Check for cancellation after callback processing
                     try Task.checkCancellation()
@@ -1402,6 +1396,7 @@ struct LoginView: View {
                     // Success is handled via onChange of authState
 
                 } catch let authSessionError as ASWebAuthenticationSessionError {
+                    await appStateManager.authentication.cancelGatewayOAuthFlow()
                     // User cancelled authentication
                     logger.notice("Signup was cancelled by user: \(authSessionError._nsError.localizedDescription)")
                     // Only set authenticationCancelled for explicit user cancellation

--- a/CatbirdTests/GatewayOAuthExchangeTests.swift
+++ b/CatbirdTests/GatewayOAuthExchangeTests.swift
@@ -1,0 +1,309 @@
+import Foundation
+import Testing
+
+@testable import Catbird
+
+@Suite("Gateway OAuth single-use exchange")
+struct GatewayOAuthExchangeTests {
+  private let callbackURL = URL(string: "https://catbird.blue/oauth/callback")!
+  private let gatewayURL = URL(string: "https://api.catbird.blue")!
+
+  @Test("login binds a cryptographic nonce and the exact callback URL")
+  func loginBinding() async throws {
+    let exchange = GatewayOAuthExchange(
+      gatewayURL: gatewayURL,
+      callbackURL: callbackURL,
+      send: { _ in throw GatewayOAuthExchangeError.unauthorized }
+    )
+
+    let loginURL = try await exchange.prepareLogin(
+      URL(string: "https://api.catbird.blue/auth/login?identifier=alice.test")!
+    )
+    let components = try #require(URLComponents(url: loginURL, resolvingAgainstBaseURL: false))
+    let query = Dictionary(
+      uniqueKeysWithValues: (components.queryItems ?? []).map { ($0.name, $0.value) })
+    let nonce = try #require(query["browser_nonce"] ?? nil)
+
+    #expect(query["identifier"] == "alice.test")
+    #expect(query["redirect_to"] == callbackURL.absoluteString)
+    #expect(nonce.count == 43)
+    #expect(nonce.allSatisfy { $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" })
+  }
+
+  @Test("a second login cannot replace a live pending browser nonce")
+  func overlappingLoginRejected() async throws {
+    let exchange = GatewayOAuthExchange(
+      gatewayURL: gatewayURL,
+      callbackURL: callbackURL,
+      send: { _ in throw GatewayOAuthExchangeError.unauthorized }
+    )
+    _ = try await exchange.prepareLogin(URL(string: "https://api.catbird.blue/auth/login")!)
+
+    await #expect(throws: GatewayOAuthExchangeError.flowInProgress) {
+      try await exchange.prepareLogin(URL(string: "https://api.catbird.blue/auth/login")!)
+    }
+  }
+
+  @Test("a native nonce expires after sixty seconds")
+  func nativeNonceExpiry() async throws {
+    let clock = TestUptime()
+    let exchange = GatewayOAuthExchange(
+      gatewayURL: gatewayURL,
+      callbackURL: callbackURL,
+      uptime: { clock.value },
+      send: { _ in throw GatewayOAuthExchangeError.unauthorized }
+    )
+    _ = try await exchange.prepareLogin(URL(string: "https://api.catbird.blue/auth/login")!)
+    clock.value = 60.001
+
+    await #expect(throws: GatewayOAuthExchangeError.unauthorized) {
+      try await exchange.redeem(
+        URL(
+          string:
+            "https://catbird.blue/oauth/callback?code=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ")!
+      )
+    }
+  }
+
+  @Test("exchange transport rejects redirects and streamed responses over budget")
+  func transportBoundaries() throws {
+    #expect(GatewayOAuthExchangeTransport.redirectTarget == nil)
+    var buffer = Data(repeating: 65, count: GatewayOAuthExchange.maximumResponseBytes)
+    try GatewayOAuthExchangeTransport.append(
+      Data(), to: &buffer, maximumBytes: GatewayOAuthExchange.maximumResponseBytes)
+    #expect(throws: GatewayOAuthExchangeError.unauthorized) {
+      try GatewayOAuthExchangeTransport.append(
+        Data([66]), to: &buffer, maximumBytes: GatewayOAuthExchange.maximumResponseBytes)
+    }
+  }
+
+  @Test("callback redemption sends JSON to the fixed endpoint with exact Origin")
+  func redemptionRequest() async throws {
+    let recorder = RequestRecorder(
+      responseData: Data(#"{"session_id":"session-123"}"#.utf8),
+      response: HTTPURLResponse(
+        url: gatewayURL.appendingPathComponent("auth/exchange"),
+        statusCode: 200,
+        httpVersion: nil,
+        headerFields: ["Content-Type": "application/json"]
+      )!
+    )
+    let exchange = GatewayOAuthExchange(
+      gatewayURL: gatewayURL,
+      callbackURL: callbackURL,
+      send: { request in await recorder.send(request) }
+    )
+    let loginURL = try await exchange.prepareLogin(
+      URL(string: "https://api.catbird.blue/auth/login")!
+    )
+    let loginComponents = try #require(URLComponents(url: loginURL, resolvingAgainstBaseURL: false))
+    let nonce = try #require(
+      loginComponents.queryItems?.first(where: { $0.name == "browser_nonce" })?.value)
+
+    let sessionID = try await exchange.redeem(
+      URL(
+        string:
+          "https://catbird.blue/oauth/callback?code=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ")!
+    )
+    let request = try #require(await recorder.request)
+    let body = try #require(request.httpBody)
+    let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: String])
+
+    #expect(sessionID == "session-123")
+    #expect(request.url == gatewayURL.appendingPathComponent("auth/exchange"))
+    #expect(request.httpMethod == "POST")
+    #expect(request.value(forHTTPHeaderField: "Origin") == "https://catbird.blue")
+    #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/json")
+    #expect(request.value(forHTTPHeaderField: "Accept") == "application/json")
+    #expect(
+      json == [
+        "code": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ",
+        "browser_nonce": nonce,
+      ])
+  }
+
+  @Test("malformed callback consumes pending nonce and replay fails locally")
+  func malformedCallbackAndReplay() async throws {
+    let recorder = RequestRecorder(
+      responseData: Data(#"{"session_id":"session-123"}"#.utf8),
+      response: HTTPURLResponse(
+        url: gatewayURL.appendingPathComponent("auth/exchange"),
+        statusCode: 200,
+        httpVersion: nil,
+        headerFields: ["Content-Type": "application/json"]
+      )!
+    )
+    let exchange = GatewayOAuthExchange(
+      gatewayURL: gatewayURL,
+      callbackURL: callbackURL,
+      send: { request in await recorder.send(request) }
+    )
+    _ = try await exchange.prepareLogin(URL(string: "https://api.catbird.blue/auth/login")!)
+
+    await #expect(throws: GatewayOAuthExchangeError.unauthorized) {
+      try await exchange.redeem(
+        URL(
+          string:
+            "https://evil.example/oauth/callback?code=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ")!
+      )
+    }
+    await #expect(throws: GatewayOAuthExchangeError.unauthorized) {
+      try await exchange.redeem(
+        URL(
+          string:
+            "https://catbird.blue/oauth/callback?code=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ")!
+      )
+    }
+    #expect(await recorder.request == nil)
+  }
+
+  @Test("wrong origin, malformed code, fragments, and extra query fields fail closed")
+  func structuralCallbackValidation() async throws {
+    let invalidURLs = [
+      "http://catbird.blue/oauth/callback?code=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ",
+      "https://catbird.blue.evil.example/oauth/callback?code=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ",
+      "https://catbird.blue/oauth/callback?code=short",
+      "https://catbird.blue/oauth/callback?code=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ&session_id=leak",
+      "https://catbird.blue/oauth/callback?code=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ#fragment",
+    ]
+
+    for rawURL in invalidURLs {
+      let exchange = GatewayOAuthExchange(
+        gatewayURL: gatewayURL,
+        callbackURL: callbackURL,
+        send: { _ in throw GatewayOAuthExchangeError.unauthorized }
+      )
+      _ = try await exchange.prepareLogin(URL(string: "https://api.catbird.blue/auth/login")!)
+      await #expect(throws: GatewayOAuthExchangeError.unauthorized) {
+        try await exchange.redeem(URL(string: rawURL)!)
+      }
+    }
+  }
+
+  @Test("HTTPS default port is equivalent when omitted or explicit")
+  func defaultHTTPSPortNormalization() async throws {
+    for (configured, callback) in [
+      (
+        "https://catbird.blue/oauth/callback",
+        "https://catbird.blue:443/oauth/callback?code=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ"
+      ),
+      (
+        "https://catbird.blue:443/oauth/callback",
+        "https://catbird.blue/oauth/callback?code=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ"
+      ),
+    ] {
+      let response = HTTPURLResponse(
+        url: gatewayURL.appendingPathComponent("auth/exchange"),
+        statusCode: 200,
+        httpVersion: nil,
+        headerFields: ["Content-Type": "application/json"]
+      )!
+      let exchange = GatewayOAuthExchange(
+        gatewayURL: gatewayURL,
+        callbackURL: URL(string: configured)!,
+        send: { request in
+          #expect(request.value(forHTTPHeaderField: "Origin") == "https://catbird.blue")
+          return (Data(#"{"session_id":"session-123"}"#.utf8), response)
+        }
+      )
+      _ = try await exchange.prepareLogin(URL(string: "https://api.catbird.blue/auth/login")!)
+      #expect(try await exchange.redeem(URL(string: callback)!) == "session-123")
+    }
+  }
+
+  @Test("non-default HTTPS callback ports are rejected")
+  func nonDefaultHTTPSPortRejected() async throws {
+    let exchange = GatewayOAuthExchange(
+      gatewayURL: gatewayURL,
+      callbackURL: callbackURL,
+      send: { _ in throw GatewayOAuthExchangeError.unauthorized }
+    )
+    _ = try await exchange.prepareLogin(URL(string: "https://api.catbird.blue/auth/login")!)
+    await #expect(throws: GatewayOAuthExchangeError.unauthorized) {
+      try await exchange.redeem(
+        URL(
+          string:
+            "https://catbird.blue:444/oauth/callback?code=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ"
+        )!
+      )
+    }
+  }
+
+  @Test("transport eagerly initializes its session and cancels unknown delegate tasks")
+  func eagerTransportAndUnknownTaskPolicy() {
+    let transport = GatewayOAuthExchangeTransport(
+      maximumBytes: GatewayOAuthExchange.maximumResponseBytes)
+    #expect(transport.hasInitializedSession)
+    #expect(
+      GatewayOAuthExchangeTransport.responseDisposition(hasPendingRequest: false) == .cancel)
+    #expect(
+      GatewayOAuthExchangeTransport.responseDisposition(hasPendingRequest: true) == .allow)
+  }
+
+  @Test("authentication manager uses one canonical gateway URL")
+  func canonicalGatewayURL() {
+    #expect(AuthenticationManager.gatewayURL == URL(string: "https://api.catbird.blue")!)
+  }
+
+  @Test("non-success and oversized or malformed responses fail closed")
+  func boundedResponse() async throws {
+    let cases: [(Data, Int, [String: String])] = [
+      (Data(#"{"session_id":"session-123"}"#.utf8), 401, ["Content-Type": "application/json"]),
+      (
+        Data(repeating: 65, count: GatewayOAuthExchange.maximumResponseBytes + 1), 200,
+        ["Content-Type": "application/json"]
+      ),
+      (Data(#"{"session_id":"session-123"}"#.utf8), 200, ["Content-Type": "text/plain"]),
+      (Data(#"{"session_id":""}"#.utf8), 200, ["Content-Type": "application/json"]),
+    ]
+
+    for (data, status, headers) in cases {
+      let response = HTTPURLResponse(
+        url: gatewayURL.appendingPathComponent("auth/exchange"),
+        statusCode: status,
+        httpVersion: nil,
+        headerFields: headers
+      )!
+      let exchange = GatewayOAuthExchange(
+        gatewayURL: gatewayURL,
+        callbackURL: callbackURL,
+        send: { _ in (data, response) }
+      )
+      _ = try await exchange.prepareLogin(URL(string: "https://api.catbird.blue/auth/login")!)
+
+      await #expect(throws: GatewayOAuthExchangeError.unauthorized) {
+        try await exchange.redeem(
+          URL(
+            string:
+              "https://catbird.blue/oauth/callback?code=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ"
+          )!)
+      }
+    }
+  }
+}
+
+private final class TestUptime: @unchecked Sendable {
+  private let lock = NSLock()
+  private var storedValue: TimeInterval = 0
+
+  var value: TimeInterval {
+    get { lock.withLock { storedValue } }
+    set { lock.withLock { storedValue = newValue } }
+  }
+}
+
+private actor RequestRecorder {
+  private(set) var request: URLRequest?
+  let responseData: Data
+  let response: URLResponse
+
+  init(responseData: Data, response: URLResponse) {
+    self.responseData = responseData
+    self.response = response
+  }
+
+  func send(_ request: URLRequest) -> (Data, URLResponse) {
+    self.request = request
+    return (responseData, response)
+  }
+}


### PR DESCRIPTION
## What changed

- replaces callback URL session credentials with nonce-bound single-use exchange codes
- validates the exact callback origin and rejects redirects, replay, overlap, and stale flows
- uses bounded streaming exchange/session responses with monotonic expiry
- removes secret-bearing callback URL logging across all authentication entry points

## Why

Implements ADR-014 for the iOS Catbird consumer so Nest session credentials never transit callback URLs.

## Validation

- focused iPhone 17 Pro OAuth suite: 8/8 passed
- full app and test target compiled
- independent adversarial review: APPROVE