### PR TITLE
Catbird: Fix sibling reply thread rendering

### DIFF
--- a/Catbird/Features/Feed/Models/ThreadReplyLayout.swift
+++ b/Catbird/Features/Feed/Models/ThreadReplyLayout.swift
@@ -1,0 +1,47 @@
+//
+//  ThreadReplyLayout.swift
+//  Catbird
+//
+
+struct ThreadReplyLayoutInput: Equatable, Sendable {
+  let id: String
+  let parentID: String?
+  let hasUnloadedReplies: Bool
+}
+
+struct ThreadReplyLayoutItem: Identifiable, Equatable, Sendable {
+  let id: String
+  let connectsToNext: Bool
+  let hasAdditionalReplies: Bool
+}
+
+struct ThreadReplyLayout: Equatable, Sendable {
+  let connectsRootToFirst: Bool
+  let items: [ThreadReplyLayoutItem]
+}
+
+enum ThreadReplyLayoutBuilder {
+  static func build(
+    rootID: String,
+    nestedItems: [ThreadReplyLayoutInput],
+    visibleLimit: Int
+  ) -> ThreadReplyLayout {
+    let visible = Array(nestedItems.prefix(max(0, visibleLimit)))
+    let omitted = nestedItems.dropFirst(visible.count)
+    let items = visible.enumerated().map { index, item in
+      let next = visible.indices.contains(index + 1) ? visible[index + 1] : nil
+
+      return ThreadReplyLayoutItem(
+        id: item.id,
+        connectsToNext: next?.parentID == item.id,
+        hasAdditionalReplies: item.hasUnloadedReplies
+          || omitted.contains(where: { $0.parentID == item.id })
+      )
+    }
+
+    return ThreadReplyLayout(
+      connectsRootToFirst: visible.first?.parentID == rootID,
+      items: items
+    )
+  }
+}

--- a/Catbird/Features/Feed/Views/Thread/UIKitThreadView.swift
+++ b/Catbird/Features/Feed/Views/Thread/UIKitThreadView.swift
@@ -2949,17 +2949,47 @@ struct ReplyView: View {
   @Binding var path: NavigationPath
   var appState: AppState
 
+  private var visibleNestedReplies: [ReplyWrapper] {
+    Array(nestedReplies.prefix(max(0, maxDepth - 1)))
+  }
+
+  private var nestedLayout: ThreadReplyLayout {
+    ThreadReplyLayoutBuilder.build(
+      rootID: replyWrapper.id,
+      nestedItems: nestedReplies.map {
+        ThreadReplyLayoutInput(
+          id: $0.id,
+          parentID: $0.parentURI,
+          hasUnloadedReplies: $0.hasReplies
+        )
+      },
+      visibleLimit: maxDepth - 1
+    )
+  }
+
+  private func parentAuthor(
+    for reply: ReplyWrapper
+  ) -> AppBskyActorDefs.ProfileViewBasic? {
+    guard let parentURI = reply.parentURI else { return nil }
+
+    if parentURI == replyWrapper.id {
+      return replyWrapper.post?.author
+    }
+
+    return nestedReplies.first(where: { $0.id == parentURI })?.post?.author
+  }
+
   var body: some View {
     switch replyWrapper.threadItem.value {
     case .appBskyUnspeccedDefsThreadItemPost(let threadItemPost):
       VStack(alignment: .leading, spacing: 0) {
         // Show the top-level reply (depth 1)
-        let showLine = !nestedReplies.isEmpty
+        let layout = nestedLayout
         
         PostView(
           post: threadItemPost.post,
           grandparentAuthor: nil,
-          isParentPost: showLine,  // Show connecting line if there are nested replies
+          isParentPost: layout.connectsRootToFirst,
           isSelectable: false,
           path: $path,
           appState: appState,
@@ -2972,90 +3002,78 @@ struct ReplyView: View {
         .padding(.vertical, 3)
         .frame(maxWidth: 550, alignment: .leading)
         
-        // Show nested replies (depth 2+) in a chain
-        if !nestedReplies.isEmpty {
-          // Only the slice we'll actually consider rendering
-          let visible = Array(nestedReplies.prefix(maxDepth - 1))
-          
-          // Find the last element in `visible` that is actually renderable as a Post
-          let lastRenderableIndex: Int? = visible.lastIndex(where: {
-            if case .appBskyUnspeccedDefsThreadItemPost = $0.threadItem.value { return true }
-            return false
-          })
-          
-          ForEach(Array(visible.enumerated()), id: \.element.id) { idx, nestedWrapper in
-            switch nestedWrapper.threadItem.value {
+        // Show nested replies (depth 2+) using their actual parent relationships.
+        if !layout.items.isEmpty {
+          ForEach(layout.items) { item in
+            if let nestedWrapper = visibleNestedReplies.first(where: { $0.id == item.id }) {
+              switch nestedWrapper.threadItem.value {
               
-            case .appBskyUnspeccedDefsThreadItemPost(let nestedPost):
-              // "Renderable last" = last visible Post cell in the chain (ignoring placeholders)
-              let isLastRenderable = (idx == lastRenderableIndex)
-              // Draw the connecting line unless this is the last rendered post and it has no more replies
-              let showNestedLine = !(isLastRenderable && !nestedWrapper.hasReplies)
-              
-              PostView(
-                post: nestedPost.post,
-                grandparentAuthor: nil,
-                isParentPost: showNestedLine,
-                isSelectable: false,
-                path: $path,
-                appState: appState,
-                hasVisibleThreadContext: true
-              )
-              .contentShape(Rectangle())
-              .onTapGesture { path.append(NavigationDestination.post(nestedPost.post.uri)) }
-              .padding(.vertical, 3)
-              .frame(maxWidth: 550, alignment: .leading)
-              
-                let shouldShowContinue = isLastRenderable && nestedPost.post.replyCount ?? 0 > 0
-              
-              if shouldShowContinue {
-                Button(action: {
-                  // Jump into the last rendered post; the server will expand from here
-                  path.append(NavigationDestination.post(nestedPost.post.uri))
-                }) {
+              case .appBskyUnspeccedDefsThreadItemPost(let nestedPost):
+                PostView(
+                  post: nestedPost.post,
+                  grandparentAuthor: parentAuthor(for: nestedWrapper),
+                  isParentPost: item.connectsToNext,
+                  isSelectable: false,
+                  path: $path,
+                  appState: appState,
+                  hasVisibleThreadContext: true
+                )
+                .contentShape(Rectangle())
+                .onTapGesture { path.append(NavigationDestination.post(nestedPost.post.uri)) }
+                .padding(.vertical, 3)
+                .frame(maxWidth: 550, alignment: .leading)
+                
+                if item.hasAdditionalReplies {
+                  Button {
+                    // Jump into the last rendered post; the server will expand from here
+                    path.append(NavigationDestination.post(nestedPost.post.uri))
+                  } label: {
+                    HStack {
+                      Text("Continue thread").appFont(AppTextRole.subheadline)
+                      Image(systemName: "chevron.right").appFont(AppTextRole.subheadline)
+                    }
+                    .foregroundColor(.accentColor)
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 12)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .contentShape(Rectangle())
+                  }
+                }
+                
+              case .appBskyUnspeccedDefsThreadItemNotFound:
+                PostNotFoundView(
+                  uri: nestedWrapper.threadItem.uri,
+                  reason: .notFound,
+                  path: $path
+                )
+                .applyAppStateEnvironment(appState)
+                
+                // Offer a way to jump into the missing leg of the chain
+                Button {
+                  path.append(NavigationDestination.post(nestedWrapper.uri))
+                } label: {
                   HStack {
                     Text("Continue thread").appFont(AppTextRole.subheadline)
                     Image(systemName: "chevron.right").appFont(AppTextRole.subheadline)
                   }
                   .foregroundColor(.accentColor)
-                  .padding(.vertical, 8)
-                  .padding(.horizontal, 12)
-                  .frame(maxWidth: .infinity, alignment: .leading)
-                  .contentShape(Rectangle())
+                  .padding(.vertical, 6)
                 }
+                
+              case .appBskyUnspeccedDefsThreadItemBlocked:
+                Text("Blocked reply")
+                  .appFont(AppTextRole.subheadline)
+                  .foregroundColor(.gray)
+                
+              case .appBskyUnspeccedDefsThreadItemNoUnauthenticated:
+                Text("Reply not available (authentication required)")
+                  .appFont(AppTextRole.subheadline)
+                  .foregroundColor(.gray)
+                
+              case .unexpected(let unexpected):
+                Text("Unexpected reply type: \(unexpected.textRepresentation)")
+                  .foregroundColor(.orange)
               }
-              
-            case .appBskyUnspeccedDefsThreadItemNotFound:
-              PostNotFoundView(
-                uri: nestedWrapper.threadItem.uri,
-                reason: .notFound,
-                path: $path
-              )
-              .applyAppStateEnvironment(appState)
-              
-              // Offer a way to jump into the missing leg of the chain
-              Button(action: { path.append(NavigationDestination.post(nestedWrapper.uri)) }) {
-                HStack {
-                  Text("Continue thread").appFont(AppTextRole.subheadline)
-                  Image(systemName: "chevron.right").appFont(AppTextRole.subheadline)
-                }
-                .foregroundColor(.accentColor)
-                .padding(.vertical, 6)
-              }
-              
-            case .appBskyUnspeccedDefsThreadItemBlocked:
-              Text("Blocked reply")
-                .appFont(AppTextRole.subheadline)
-                .foregroundColor(.gray)
-              
-            case .appBskyUnspeccedDefsThreadItemNoUnauthenticated:
-              Text("Reply not available (authentication required)")
-                .appFont(AppTextRole.subheadline)
-                .foregroundColor(.gray)
-              
-            case .unexpected(let unexpected):
-              Text("Unexpected reply type: \(unexpected.textRepresentation)")
-                .foregroundColor(.orange)
             }
           }
         }
@@ -3114,6 +3132,18 @@ extension ReplyWrapper {
          .appBskyUnspeccedDefsThreadItemNoUnauthenticated, .unexpected:
       return nil
     }
+  }
+
+  /// The URI this post directly replies to, when its record is available.
+  var parentURI: String? {
+    guard let post,
+      case .knownType(let record) = post.record,
+      let feedPost = record as? AppBskyFeedPost
+    else {
+      return nil
+    }
+
+    return feedPost.reply?.parent.uri.uriString()
   }
 
   /// URI accessor that works for all thread item types

--- a/Catbird/Features/Feed/Views/Thread/UIKitThreadView.swift
+++ b/Catbird/Features/Feed/Views/Thread/UIKitThreadView.swift
@@ -2985,6 +2985,7 @@ struct ReplyView: View {
       VStack(alignment: .leading, spacing: 0) {
         // Show the top-level reply (depth 1)
         let layout = nestedLayout
+        let visibleReplies = visibleNestedReplies
         
         PostView(
           post: threadItemPost.post,

--- a/Catbird/Features/Feed/Views/Thread/UIKitThreadView.swift
+++ b/Catbird/Features/Feed/Views/Thread/UIKitThreadView.swift
@@ -3005,7 +3005,7 @@ struct ReplyView: View {
         // Show nested replies (depth 2+) using their actual parent relationships.
         if !layout.items.isEmpty {
           ForEach(layout.items) { item in
-            if let nestedWrapper = visibleNestedReplies.first(where: { $0.id == item.id }) {
+            if let nestedWrapper = visibleReplies.first(where: { $0.id == item.id }) {
               switch nestedWrapper.threadItem.value {
               
               case .appBskyUnspeccedDefsThreadItemPost(let nestedPost):

--- a/CatbirdTests/ThreadReplyLayoutTests.swift
+++ b/CatbirdTests/ThreadReplyLayoutTests.swift
@@ -1,0 +1,57 @@
+//
+//  ThreadReplyLayoutTests.swift
+//  CatbirdTests
+//
+
+import Testing
+@testable import Catbird
+
+@Suite("Thread reply layout")
+struct ThreadReplyLayoutTests {
+  @Test("Sibling replies do not connect to each other")
+  func siblingRepliesDoNotConnect() {
+    let layout = ThreadReplyLayoutBuilder.build(
+      rootID: "natalie",
+      nestedItems: [
+        .init(id: "gee", parentID: "natalie", hasUnloadedReplies: false),
+        .init(id: "josh", parentID: "natalie", hasUnloadedReplies: false)
+      ],
+      visibleLimit: 2
+    )
+
+    #expect(layout.connectsRootToFirst)
+    #expect(layout.items.map(\.id) == ["gee", "josh"])
+    #expect(layout.items.map(\.connectsToNext) == [false, false])
+  }
+
+  @Test("A direct child keeps the thread connector")
+  func directChildKeepsThreadConnector() {
+    let layout = ThreadReplyLayoutBuilder.build(
+      rootID: "root",
+      nestedItems: [
+        .init(id: "child", parentID: "root", hasUnloadedReplies: false),
+        .init(id: "grandchild", parentID: "child", hasUnloadedReplies: false)
+      ],
+      visibleLimit: 2
+    )
+
+    #expect(layout.connectsRootToFirst)
+    #expect(layout.items.map(\.connectsToNext) == [true, false])
+  }
+
+  @Test("An omitted child keeps the continuation affordance")
+  func omittedChildKeepsContinuationAffordance() throws {
+    let layout = ThreadReplyLayoutBuilder.build(
+      rootID: "root",
+      nestedItems: [
+        .init(id: "visible", parentID: "root", hasUnloadedReplies: false),
+        .init(id: "omitted", parentID: "visible", hasUnloadedReplies: false)
+      ],
+      visibleLimit: 1
+    )
+
+    let visible = try #require(layout.items.first)
+    #expect(!visible.connectsToNext)
+    #expect(visible.hasAdditionalReplies)
+  }
+}


### PR DESCRIPTION
## Summary

- derive nested reply connectors from each post's actual parent URI instead of flat API order
- show the real parent author in the existing "in reply to" label for nested replies
- preserve legitimate child chains and the continuation affordance when a child is beyond the preview limit
- add focused regression coverage for siblings, direct children, and omitted children

## Testing

- `ThreadReplyLayoutTests`: 3 passed, 0 failed after rebasing onto current `main`
- `CatbirdTests` excluding the unrelated existing drawer assertion: 173 passed, 0 failed
- iPhone 17 Pro simulator build: succeeded
- SwiftLint on the three changed files: completed with no warnings in the new/changed block (remaining warnings are pre-existing elsewhere in `UIKitThreadView.swift`)

## Existing unrelated test failure

The complete `CatbirdTests` run has one deterministic failure outside this change:

`ConcentricLiquidGlassDrawerTests.backdropTuningScrubsBackdropBlurWithLightScrim()` expects scrim opacity `0.10`, while current code returns `0.18`. The test was rerun in isolation and fails the same way; this PR does not touch the drawer implementation or test.

## Runtime note

The built app installs and launches in the simulator. Visual capture is blocked by the active Xcode beta's missing `SimulatorKit.framework`; both accessibility snapshot and screenshot tooling failed before the affected signed-in thread could be compared.
