### PR TITLE
security: serialize MLS foreground resume and NSE cleanup

### DIFF
--- a/Catbird.xcodeproj/project.pbxproj
+++ b/Catbird.xcodeproj/project.pbxproj
@@ -196,6 +196,7 @@
 				Services/MLS/MLSKeyPackageMonitor.swift,
 				Services/MLS/MLSMessagePadding.swift,
 				Services/MLS/MLSMessageValidator.swift,
+				Services/MLS/NSENotificationProcessingLeases.swift,
 				Services/MLS/MLSSyncValidator.swift,
 				Services/MLS/MLSWelcomeCoordinator.swift,
 				Services/MLS/Models/KeyPackageBatchResult.swift,

--- a/Catbird/App/CatbirdApp.swift
+++ b/Catbird/App/CatbirdApp.swift
@@ -219,7 +219,6 @@ private func forceCloseSceneSuspensionSynchronously(
     MLSClient.interruptAllContexts()
     MLSCoreContext.interruptAllContexts()
     MLSClient.emergencyCloseAllContexts(reason: reason)
-    MLSCoreContext.emergencyCloseAllContexts()
     manager?.markRustRuntimeClosedForSuspend(reason: reason)
     MLSForegroundResumeCoordinator.markRustRuntimeClosedForSuspension(
       claim.transitionToken,
@@ -1492,8 +1491,8 @@ private extension CatbirdApp {
     // ═══════════════════════════════════════════════════════════════════════════
     if newPhase == .inactive || newPhase == .background {
       // Block new MLS FFI work immediately while we transition to background.
-      // MLSClient delegates UniFFI MlsContext ownership to MLSCoreContext; both
-      // gates are set because callers enter through both surfaces.
+      // Every entry path uses the coupled MLSClient lifecycle boundary, which
+      // owns both client and Core admission gates.
       if let manager = appStateManager.lifecycle.appState?.mlsConversationManager {
         suspensionManager = manager
         rustPathAvailable = manager.suspendMLSOperations()
@@ -1505,7 +1504,6 @@ private extension CatbirdApp {
           reason: "scenePhase → \(String(describing: newPhase))"
         )
       }
-      MLSCoreContext.markSuspensionInProgress()
     }
 
     #if os(iOS)
@@ -1629,7 +1627,6 @@ private extension CatbirdApp {
             MLSClient.emergencyCloseAllContexts(
               reason: "scenePhase active→\(String(describing: newPhase))"
             )
-            MLSCoreContext.emergencyCloseAllContexts()
             manager.markRustRuntimeClosedForSuspend(
               reason: "scenePhase active→\(String(describing: newPhase)) prepared close"
             )

--- a/Catbird/App/CatbirdApp.swift
+++ b/Catbird/App/CatbirdApp.swift
@@ -30,26 +30,190 @@ import FoundationModels
 // App-wide logger
 let logger = Logger(subsystem: "blue.catbird", category: "AppLifecycle")
 
+enum MLSForegroundResumeOutcome: Equatable {
+  case managerUnavailable
+  case preparationFailed
+  case failedStillSuspended
+  case staleTransition
+  case resumed
+}
+
+@MainActor
+enum MLSForegroundResumeCoordinator {
+  private static var sceneTransitionGeneration: UInt64 = 0
+  private static var currentScenePhase: ScenePhase?
+  private static var rustRuntimeClosedForCurrentSuspension = false
+
+  static func recordSceneTransition(to phase: ScenePhase) -> UInt64 {
+    sceneTransitionGeneration &+= 1
+    currentScenePhase = phase
+    if phase == .active {
+      rustRuntimeClosedForCurrentSuspension = false
+    }
+    return sceneTransitionGeneration
+  }
+
+  static func isCurrentActiveTransition(_ generation: UInt64) -> Bool {
+    isCurrentTransition(generation, expectedPhase: .active)
+  }
+
+  static func isCurrentTransition(_ generation: UInt64, expectedPhase: ScenePhase) -> Bool {
+    generation == sceneTransitionGeneration && currentScenePhase == expectedPhase
+  }
+
+  static var isApplicationActive: Bool {
+    currentScenePhase == .active
+  }
+
+  @discardableResult
+  static func markRustRuntimeClosedForSuspension(
+    _ generation: UInt64,
+    expectedPhase: ScenePhase
+  ) -> Bool {
+    guard expectedPhase != .active,
+          isCurrentTransition(generation, expectedPhase: expectedPhase)
+    else {
+      return false
+    }
+    rustRuntimeClosedForCurrentSuspension = true
+    return true
+  }
+
+  static func hasClosedRustRuntimeForSuspension(
+    _ generation: UInt64,
+    expectedPhase: ScenePhase
+  ) -> Bool {
+    expectedPhase != .active
+      && isCurrentTransition(generation, expectedPhase: expectedPhase)
+      && rustRuntimeClosedForCurrentSuspension
+  }
+
+  static func run(
+    managerAvailable: Bool,
+    resumeStillCurrent: () -> Bool,
+    prepareStorage: () async throws -> Void,
+    resumeManager: () async -> MLSResumeResult,
+    reassertSuspensionAfterStaleResume: () -> Void,
+    reloadProjection: () async -> Void,
+    performBackup: () async -> Void
+  ) async -> MLSForegroundResumeOutcome {
+    guard managerAvailable else { return .managerUnavailable }
+    guard resumeStillCurrent() else { return .staleTransition }
+
+    do {
+      try await prepareStorage()
+    } catch {
+      return .preparationFailed
+    }
+    guard resumeStillCurrent() else { return .staleTransition }
+
+    switch await resumeManager() {
+    case .failedStillSuspended:
+      return .failedStillSuspended
+    case .resumed:
+      guard resumeStillCurrent() else {
+        reassertSuspensionAfterStaleResume()
+        return .staleTransition
+      }
+      await reloadProjection()
+      guard resumeStillCurrent() else {
+        reassertSuspensionAfterStaleResume()
+        return .staleTransition
+      }
+      await performBackup()
+      return .resumed
+    }
+  }
+}
+
+@MainActor
+final class MLSSceneSuspensionCloseClaim {
+  let transitionToken: UInt64
+  let expectedPhase: ScenePhase
+  private var claimed = false
+
+  init(transitionToken: UInt64, expectedPhase: ScenePhase) {
+    self.transitionToken = transitionToken
+    self.expectedPhase = expectedPhase
+  }
+
+  func claimExpirationIfCurrent() -> Bool {
+    claimIfCurrent()
+  }
+
+  func claimNormalCloseIfCurrent() -> Bool {
+    claimIfCurrent()
+  }
+
+  private func claimIfCurrent() -> Bool {
+    guard !claimed,
+          expectedPhase != .active,
+          MLSForegroundResumeCoordinator.isCurrentTransition(
+            transitionToken,
+            expectedPhase: expectedPhase
+          )
+    else {
+      return false
+    }
+    claimed = true
+    return true
+  }
+}
+
+enum MLSSuspensionCloseOutcome: Equatable {
+  case rustPathUnavailable
+  case preparationFailed
+  case staleTransition
+  case closed
+}
+
+@MainActor
+enum MLSSuspensionCloseCoordinator {
+  static func run(
+    rustPathAvailable: Bool,
+    transitionStillCurrent: () -> Bool,
+    prepareRustRuntime: () async -> Bool,
+    closePreparedRuntime: () -> Void
+  ) async -> MLSSuspensionCloseOutcome {
+    guard rustPathAvailable else { return .rustPathUnavailable }
+    guard transitionStillCurrent() else { return .staleTransition }
+    guard await prepareRustRuntime() else { return .preparationFailed }
+    guard transitionStillCurrent() else { return .staleTransition }
+    closePreparedRuntime()
+    return .closed
+  }
+}
+
 #if os(iOS)
-/// Force the rustFull runtime closed immediately during background-task expiration.
-/// The invalidation must happen synchronously before the handler returns so iOS
-/// cannot suspend the process with a stale orchestrator runtime still cached.
-private func closeRustRuntimeSynchronousAfterExpiration(
-  appStateManager: AppStateManager,
+/// Force the exact scene suspension's rustFull runtime closed immediately during
+/// background-task expiration. Claim validation, close, and lifecycle marking all
+/// execute in one MainActor turn so a newer foreground generation cannot interleave.
+private func forceCloseSceneSuspensionSynchronously(
+  claim: MLSSceneSuspensionCloseClaim,
+  manager: MLSConversationManager?,
   reason: String
 ) {
+  let closeIfClaimed: @MainActor () -> Void = {
+    guard claim.claimExpirationIfCurrent() else { return }
+    MLSClient.interruptAllContexts()
+    MLSCoreContext.interruptAllContexts()
+    MLSClient.emergencyCloseAllContexts(reason: reason)
+    MLSCoreContext.emergencyCloseAllContexts()
+    manager?.markRustRuntimeClosedForSuspend(reason: reason)
+    MLSForegroundResumeCoordinator.markRustRuntimeClosedForSuspension(
+      claim.transitionToken,
+      expectedPhase: claim.expectedPhase
+    )
+  }
+
   if Thread.isMainThread {
     MainActor.assumeIsolated {
-      appStateManager.lifecycle.appState?.mlsConversationManager?.markRustRuntimeClosedForSuspend(
-        reason: reason
-      )
+      closeIfClaimed()
     }
   } else {
     DispatchQueue.main.sync {
       MainActor.assumeIsolated {
-        appStateManager.lifecycle.appState?.mlsConversationManager?.markRustRuntimeClosedForSuspend(
-          reason: reason
-        )
+        closeIfClaimed()
       }
     }
   }
@@ -1264,7 +1428,15 @@ private extension CatbirdApp {
     }
   }
 
+  @MainActor
   func handleScenePhaseChange(from oldPhase: ScenePhase, to newPhase: ScenePhase) {
+    let sceneTransitionToken = MLSForegroundResumeCoordinator.recordSceneTransition(to: newPhase)
+    let suspensionCloseClaim = MLSSceneSuspensionCloseClaim(
+      transitionToken: sceneTransitionToken,
+      expectedPhase: newPhase
+    )
+    var suspensionManager: MLSConversationManager?
+    var rustPathAvailable = false
     MLSSuspensionFlightRecorder.shared.record(
       .scenePhaseChange,
       details: "\(String(describing: oldPhase)) → \(String(describing: newPhase))",
@@ -1301,11 +1473,19 @@ private extension CatbirdApp {
       // Block new MLS FFI work immediately while we transition to background.
       // MLSClient delegates UniFFI MlsContext ownership to MLSCoreContext; both
       // gates are set because callers enter through both surfaces.
-      MLSClient.markSuspensionInProgress(reason: "scenePhase → \(String(describing: newPhase))")
+      if let manager = appStateManager.lifecycle.appState?.mlsConversationManager {
+        suspensionManager = manager
+        rustPathAvailable = manager.suspendMLSOperations()
+      } else {
+        // Without an instantiated manager there is no lifecycle owner. Keep the
+        // transition ownerless so later cleanup cannot abandon the suspension.
+        MLSClient.markSuspensionInProgress(reason: "scenePhase → \(String(describing: newPhase))")
+      }
       MLSCoreContext.markSuspensionInProgress()
     }
 
     #if os(iOS)
+    let suspensionOwner = suspensionManager
     // CRITICAL FIX: Synchronously acquire background task assertion
     // This bridges the gap between the synchronous onChange callback and the async Task execution.
     // Without this, aggressive OS suspension (especially in Release builds) can freeze the app
@@ -1316,12 +1496,9 @@ private extension CatbirdApp {
       taskId = UIApplication.shared.beginBackgroundTask(withName: "ScenePhaseTransition") {
         // Expiration: iOS is reclaiming time. Force-close everything NOW.
         logger.warning("ScenePhaseTransition expired — force-closing all contexts")
-        MLSClient.interruptAllContexts()
-        MLSCoreContext.interruptAllContexts()
-        MLSClient.emergencyCloseAllContexts(reason: "ScenePhaseTransition expired")
-        MLSCoreContext.emergencyCloseAllContexts()
-        closeRustRuntimeSynchronousAfterExpiration(
-          appStateManager: appStateManager,
+        forceCloseSceneSuspensionSynchronously(
+          claim: suspensionCloseClaim,
+          manager: suspensionOwner,
           reason: "ScenePhaseTransition expired"
         )
         if taskId != .invalid {
@@ -1332,21 +1509,12 @@ private extension CatbirdApp {
     }
     #endif
 
-    if newPhase == .inactive || newPhase == .background {
+    if newPhase == .inactive || newPhase == .background, !rustPathAvailable {
       #if os(iOS)
-      if let appState = appStateManager.lifecycle.appState {
-        let manager = appState.mlsConversationManager
-        let rustPrepareSucceeded = MainActor.assumeIsolated {
-          manager?.suspendMLSOperations() ?? false
-        }
-        if !rustPrepareSucceeded {
-          MLSClient.interruptAllContexts()
-          MLSCoreContext.interruptAllContexts()
-        }
-      } else {
-        MLSClient.interruptAllContexts()
-        MLSCoreContext.interruptAllContexts()
-      }
+      // A missing rustFull runtime has no normal close path. Keep every gate closed
+      // and interrupt any straggler; only background-task expiration may force-close.
+      MLSClient.interruptAllContexts()
+      MLSCoreContext.interruptAllContexts()
       #else
       MLSClient.interruptAllContexts()
       MLSCoreContext.interruptAllContexts()
@@ -1372,6 +1540,14 @@ private extension CatbirdApp {
 
       await FeedStateStore.shared.handleScenePhaseChange(newPhase)
 
+      guard MLSForegroundResumeCoordinator.isCurrentTransition(
+        sceneTransitionToken,
+        expectedPhase: newPhase
+      ) else {
+        logger.debug("Skipping stale scene lifecycle task after feed-state update")
+        return
+      }
+
 #if os(iOS)
       // ═══════════════════════════════════════════════════════════════════════════
       // 0xdead10cc FIX: Close Rust FFI connections on background.
@@ -1393,34 +1569,89 @@ private extension CatbirdApp {
         }
       }
 
-      if oldPhase == .active, (newPhase == .inactive || newPhase == .background) {
+      if newPhase == .inactive || newPhase == .background {
         // WAL health snapshot BEFORE suspension — baseline for corruption detection
         MLSGRDBManager.probeWALHealth(for: "all", label: "APP_SUSPENDING")
 
         // RAII background task protects the close operations
         let bgTask = CatbirdBackgroundTask(name: "MLSSuspensionClose") {
           // Last resort: iOS is killing our background time
-          MLSClient.interruptAllContexts()
-          MLSCoreContext.interruptAllContexts()
-          MLSClient.emergencyCloseAllContexts(reason: "MLSSuspensionClose expired")
-          MLSCoreContext.emergencyCloseAllContexts()
-          closeRustRuntimeSynchronousAfterExpiration(
-            appStateManager: appStateManager,
+          forceCloseSceneSuspensionSynchronously(
+            claim: suspensionCloseClaim,
+            manager: suspensionOwner,
             reason: "MLSSuspensionClose expired"
           )
         }
 
-        // Step 1: Close Rust FFI connections — releases WAL locks in App Group
-        MLSClient.emergencyCloseAllContexts(reason: "scenePhase active→\(String(describing: newPhase))")
-        MLSCoreContext.emergencyCloseAllContexts()
-        appStateManager.lifecycle.appState?.mlsConversationManager?.markRustRuntimeClosedForSuspend(
-          reason: "scenePhase active→\(String(describing: newPhase)) emergency close"
+        guard let manager = suspensionOwner else {
+          bgTask.end()
+          logger.warning("Skipping normal Rust close without the suspension-owning manager")
+          return
+        }
+
+        let closeOutcome = await MLSSuspensionCloseCoordinator.run(
+          rustPathAvailable: rustPathAvailable,
+          transitionStillCurrent: {
+            MLSForegroundResumeCoordinator.isCurrentTransition(
+              sceneTransitionToken,
+              expectedPhase: newPhase
+            )
+          },
+          prepareRustRuntime: {
+            await manager.prepareRustRuntimeForSuspensionAfterDrain(timeout: 5)
+          },
+          closePreparedRuntime: {
+            guard suspensionCloseClaim.claimNormalCloseIfCurrent() else { return }
+            MLSClient.emergencyCloseAllContexts(
+              reason: "scenePhase active→\(String(describing: newPhase))"
+            )
+            MLSCoreContext.emergencyCloseAllContexts()
+            manager.markRustRuntimeClosedForSuspend(
+              reason: "scenePhase active→\(String(describing: newPhase)) prepared close"
+            )
+            MLSForegroundResumeCoordinator.markRustRuntimeClosedForSuspension(
+              sceneTransitionToken,
+              expectedPhase: newPhase
+            )
+          }
         )
+
+        switch closeOutcome {
+        case .closed:
+          break
+        case .staleTransition:
+          bgTask.end()
+          logger.debug("Skipping stale suspension lifecycle task after Rust preparation")
+          return
+        case .preparationFailed:
+          bgTask.end()
+          logger.error("Rust suspension preparation failed; keeping lifecycle gates closed")
+          return
+        case .rustPathUnavailable:
+          guard MLSForegroundResumeCoordinator.hasClosedRustRuntimeForSuspension(
+            sceneTransitionToken,
+            expectedPhase: newPhase
+          ) else {
+            bgTask.end()
+            logger.warning("Rust suspension path unavailable; keeping lifecycle gates closed")
+            return
+          }
+          logger.debug("Reusing Rust close completed by the preceding suspended phase")
+        }
 
         // Step 2: Give GRDB time to complete its auto-suspension (checkpoint + release readers).
         // observesSuspensionNotifications fires on didEnterBackground which may be
         // slightly after scenePhase changes. 200ms is enough for the checkpoint to complete.
         try? await Task.sleep(nanoseconds: 200_000_000)
+
+        guard MLSForegroundResumeCoordinator.isCurrentTransition(
+          sceneTransitionToken,
+          expectedPhase: newPhase
+        ) else {
+          bgTask.end()
+          logger.debug("Skipping stale suspension lifecycle task after close delay")
+          return
+        }
 
         // Step 3: NOW signal NSE that it's safe to decrypt.
         // At this point, Rust FFI is closed and GRDB is fully suspended.
@@ -1439,52 +1670,7 @@ private extension CatbirdApp {
       if (oldPhase == .background || oldPhase == .inactive), newPhase == .active {
         // WAL health snapshot ON RESUME — detect corruption from NSE activity while suspended
         MLSGRDBManager.probeWALHealth(for: "all", label: "APP_RESUMING")
-
-        // CRITICAL: Clear suspension flag FIRST so getContext() works
-        MLSCoreContext.clearSuspensionFlag()
-        MLSClient.clearSuspensionFlag(reason: "scenePhase → active")
-
-        // Resume GRDB and coordination
-        MLSDatabaseCoordinator.shared.resumeFromSuspension()
-
-        if let appState = appStateManager.lifecycle.appState {
-          do {
-            let resumeResult = try await MLSGRDBManager.shared.prepareForForegroundResume(
-              for: appState.userDID
-            )
-            switch resumeResult {
-            case .ready:
-              logger.debug("✅ [RESUME] MLS storage healthy before foreground reopen")
-            case .repaired:
-              logger.info("✅ [RESUME] MLS storage repaired before foreground reopen")
-            case .reset:
-              logger.warning(
-                "🧰 [RESUME] MLS storage was rebuilt before foreground reopen after verified corruption"
-              )
-            }
-            appState.mlsServiceState.clearDatabaseFailure()
-          } catch {
-            logger.error("❌ [RESUME] Foreground MLS preparation failed: \(error.localizedDescription)")
-            // Don't return early — let the app continue to the MLS state reload.
-            // The conversation view will retry loading, and the pool may recover
-            // on its own once GRDB fully resumes. Blocking here just guarantees
-            // "Couldn't load messages" with no chance of recovery.
-            logger.warning("🔄 [RESUME] Continuing despite preparation failure — pool may self-heal")
-          }
-
-          // Creates fresh Rust connections on demand
-          await appState.reloadMLSStateFromDisk()
-
-          // Resume MLS operations that were suspended during backgrounding
-          if let manager = await appState.getMLSConversationManager() {
-            await manager.resumeMLSOperations()
-          }
-
-          // Check if auto-backup is needed
-          if let backupManager = appState.backupManager {
-            await backupManager.checkAndPerformAutoBackupIfNeeded()
-          }
-        }
+        await resumeMLSAfterReturningToForeground(transitionToken: sceneTransitionToken)
       }
 #endif
 
@@ -1499,6 +1685,72 @@ private extension CatbirdApp {
         logger.info("✅ Background scheduled - GRDB auto-suspended, Rust FFI closed")
 #endif
       }
+    }
+  }
+
+  @MainActor
+  private func resumeMLSAfterReturningToForeground(transitionToken: UInt64) async {
+    let appState = appStateManager.lifecycle.appState
+    let manager = appState?.mlsConversationManager
+
+    let outcome = await MLSForegroundResumeCoordinator.run(
+      managerAvailable: manager != nil,
+      resumeStillCurrent: {
+        MLSForegroundResumeCoordinator.isCurrentActiveTransition(transitionToken)
+      },
+      prepareStorage: {
+        guard let appState else { return }
+        let preparation = try await MLSGRDBManager.shared.prepareForForegroundResume(
+          for: appState.userDID
+        )
+        switch preparation {
+        case .ready:
+          logger.debug("✅ [RESUME] MLS storage healthy before foreground reopen")
+        case .repaired:
+          logger.info("✅ [RESUME] MLS storage repaired before foreground reopen")
+        case .reset:
+          logger.warning(
+            "🧰 [RESUME] MLS storage was rebuilt before foreground reopen after verified corruption"
+          )
+        }
+        appState.mlsServiceState.clearDatabaseFailure()
+      },
+      resumeManager: {
+        guard let manager else { return .failedStillSuspended }
+        return await manager.resumeMLSOperations()
+      },
+      reassertSuspensionAfterStaleResume: {
+        guard !MLSForegroundResumeCoordinator.isApplicationActive else {
+          return
+        }
+
+        // The newer inactive/background transition already owns suspension and
+        // preparation. Only interrupt stragglers here; never advance its generation
+        // or close beneath its in-flight drain.
+        MLSClient.interruptAllContexts()
+        MLSCoreContext.interruptAllContexts()
+      },
+      reloadProjection: {
+        await appState?.reloadMLSProjectionFromDisk()
+      },
+      performBackup: {
+        if let backupManager = appState?.backupManager {
+          await backupManager.checkAndPerformAutoBackupIfNeeded()
+        }
+      }
+    )
+
+    switch outcome {
+    case .managerUnavailable:
+      logger.warning("⏭️ [RESUME] No MLS manager; keeping MLS lifecycle gates closed")
+    case .preparationFailed:
+      logger.error("❌ [RESUME] Foreground MLS preparation failed; keeping MLS lifecycle gates closed")
+    case .failedStillSuspended:
+      logger.error("❌ [RESUME] MLS manager resume failed; lifecycle gates remain closed")
+    case .staleTransition:
+      logger.warning("⏭️ [RESUME] Discarded stale foreground transition")
+    case .resumed:
+      logger.info("✅ [RESUME] MLS transaction completed and UI projection reloaded")
     }
   }
 

--- a/Catbird/App/CatbirdApp.swift
+++ b/Catbird/App/CatbirdApp.swift
@@ -212,14 +212,24 @@ enum MLSSuspensionCloseCoordinator {
 private func forceCloseSceneSuspensionSynchronously(
   claim: MLSSceneSuspensionCloseClaim,
   manager: MLSConversationManager?,
+  contextFreeSuspensionOwner: MLSContextFreeLifecycleSuspensionOwner?,
   reason: String
 ) {
   let closeIfClaimed: @MainActor () -> Void = {
     guard claim.claimExpirationIfCurrent() else { return }
-    MLSClient.interruptAllContexts()
-    MLSCoreContext.interruptAllContexts()
-    MLSClient.emergencyCloseAllContexts(reason: reason)
-    manager?.markRustRuntimeClosedForSuspend(reason: reason)
+    if let manager {
+      MLSClient.interruptAllContexts()
+      MLSCoreContext.interruptAllContexts()
+      MLSClient.emergencyCloseAllContexts(reason: reason)
+      manager.markRustRuntimeClosedForSuspend(reason: reason)
+    } else {
+      guard
+        let contextFreeSuspensionOwner,
+        contextFreeSuspensionOwner.emergencyCloseAllContextsIfOwned(reason: reason)
+      else {
+        return
+      }
+    }
     MLSForegroundResumeCoordinator.markRustRuntimeClosedForSuspension(
       claim.transitionToken,
       expectedPhase: claim.expectedPhase
@@ -1456,6 +1466,7 @@ private extension CatbirdApp {
       expectedPhase: newPhase
     )
     var suspensionManager: MLSConversationManager?
+    var contextFreeSuspensionOwner: MLSContextFreeLifecycleSuspensionOwner?
     var rustPathAvailable = false
     MLSSuspensionFlightRecorder.shared.record(
       .scenePhaseChange,
@@ -1503,11 +1514,13 @@ private extension CatbirdApp {
         appStateManager.beginContextFreeMLSSuspension(
           reason: "scenePhase → \(String(describing: newPhase))"
         )
+        contextFreeSuspensionOwner = appStateManager.contextFreeMLSSuspensionOwner
       }
     }
 
     #if os(iOS)
     let suspensionOwner = suspensionManager
+    let contextFreeOwner = contextFreeSuspensionOwner
     // CRITICAL FIX: Synchronously acquire background task assertion
     // This bridges the gap between the synchronous onChange callback and the async Task execution.
     // Without this, aggressive OS suspension (especially in Release builds) can freeze the app
@@ -1521,6 +1534,7 @@ private extension CatbirdApp {
         forceCloseSceneSuspensionSynchronously(
           claim: suspensionCloseClaim,
           manager: suspensionOwner,
+          contextFreeSuspensionOwner: contextFreeOwner,
           reason: "ScenePhaseTransition expired"
         )
         if taskId != .invalid {
@@ -1601,6 +1615,7 @@ private extension CatbirdApp {
           forceCloseSceneSuspensionSynchronously(
             claim: suspensionCloseClaim,
             manager: suspensionOwner,
+            contextFreeSuspensionOwner: contextFreeOwner,
             reason: "MLSSuspensionClose expired"
           )
         }

--- a/Catbird/App/CatbirdApp.swift
+++ b/Catbird/App/CatbirdApp.swift
@@ -38,6 +38,12 @@ enum MLSForegroundResumeOutcome: Equatable {
   case resumed
 }
 
+enum MLSContextFreeForegroundResumeOutcome: Equatable {
+  case failedStillSuspended
+  case staleTransition
+  case resumed
+}
+
 @MainActor
 enum MLSForegroundResumeCoordinator {
   private static var sceneTransitionGeneration: UInt64 = 0
@@ -123,6 +129,21 @@ enum MLSForegroundResumeCoordinator {
       await performBackup()
       return .resumed
     }
+  }
+
+  static func runContextFree(
+    resumeStillCurrent: () -> Bool,
+    releaseOwnedSuspension: () async -> Bool
+  ) async -> MLSContextFreeForegroundResumeOutcome {
+    guard resumeStillCurrent() else { return .staleTransition }
+
+    let released = await releaseOwnedSuspension()
+
+    // The Core release performs the security decision through a two-sided owner and
+    // generation CAS. This post-await check only classifies the UI transition outcome;
+    // it must never clear or reassert either global gate.
+    guard resumeStillCurrent() else { return .staleTransition }
+    return released ? .resumed : .failedStillSuspended
   }
 }
 
@@ -1477,9 +1498,12 @@ private extension CatbirdApp {
         suspensionManager = manager
         rustPathAvailable = manager.suspendMLSOperations()
       } else {
-        // Without an instantiated manager there is no lifecycle owner. Keep the
-        // transition ownerless so later cleanup cannot abandon the suspension.
-        MLSClient.markSuspensionInProgress(reason: "scenePhase → \(String(describing: newPhase))")
+        // Backgrounding can precede the first chat. Bind this no-context transition
+        // to the process-stable AppStateManager owner so only its exact generation
+        // can reopen admission when the matching foreground transition arrives.
+        appStateManager.beginContextFreeMLSSuspension(
+          reason: "scenePhase → \(String(describing: newPhase))"
+        )
       }
       MLSCoreContext.markSuspensionInProgress()
     }
@@ -1693,8 +1717,35 @@ private extension CatbirdApp {
     let appState = appStateManager.lifecycle.appState
     let manager = appState?.mlsConversationManager
 
+    guard let manager else {
+      // Capture the exact suspension owner before the first await. A newer
+      // background transition rotates AppStateManager to a different owner,
+      // so this stale task cannot acquire its Core release capability.
+      let contextFreeSuspensionOwner = appStateManager.contextFreeMLSSuspensionOwner
+      let contextFreeOutcome = await MLSForegroundResumeCoordinator.runContextFree(
+        resumeStillCurrent: {
+          MLSForegroundResumeCoordinator.isCurrentActiveTransition(transitionToken)
+        },
+        releaseOwnedSuspension: {
+          await contextFreeSuspensionOwner.resumeSuspensionIfOwnedAndContextFree()
+        }
+      )
+
+      switch contextFreeOutcome {
+      case .failedStillSuspended:
+        logger.warning(
+          "⏭️ [RESUME] No MLS manager and no matching context-free suspension; gates remain closed"
+        )
+      case .staleTransition:
+        logger.warning("⏭️ [RESUME] Discarded stale context-free foreground transition")
+      case .resumed:
+        logger.info("✅ [RESUME] Released exact context-free MLS lifecycle suspension")
+      }
+      return
+    }
+
     let outcome = await MLSForegroundResumeCoordinator.run(
-      managerAvailable: manager != nil,
+      managerAvailable: true,
       resumeStillCurrent: {
         MLSForegroundResumeCoordinator.isCurrentActiveTransition(transitionToken)
       },
@@ -1716,7 +1767,6 @@ private extension CatbirdApp {
         appState.mlsServiceState.clearDatabaseFailure()
       },
       resumeManager: {
-        guard let manager else { return .failedStillSuspended }
         return await manager.resumeMLSOperations()
       },
       reassertSuspensionAfterStaleResume: {

--- a/Catbird/Core/State/AppState.swift
+++ b/Catbird/Core/State/AppState.swift
@@ -1058,7 +1058,15 @@ final class AppState {
             logger.info("MLS: Shutting down conversation manager with timeout...")
 
             let oldManager = manager
-            let shutdownTask = Task { await oldManager.shutdown() }
+            let rustAvailable = oldManager.suspendMLSOperations()
+            if !rustAvailable {
+                logger.info("MLS: Account-switch suspension has no live rustFull runtime; Core shutdown will decide safety")
+            }
+            guard let authorization = oldManager.authorizeSuspensionAbandonmentForAccountSwitch() else {
+                logger.critical("🚨 MLS: Account-switch suspension ownership unavailable; refusing shutdown")
+                return
+            }
+            let shutdownTask = Task { await oldManager.shutdown(accountSwitchSuspensionAuthorization: authorization) }
 
             let shutdownResult: Bool? = await withTaskGroup(of: Bool?.self) { group in
                 // Task 1: Wait for graceful shutdown (do NOT run shutdown inside the group so we don't cancel it on timeout)
@@ -1843,31 +1851,39 @@ final class AppState {
             await manager.reloadStateFromDisk()
             logger.info("✅ [AppState] MLS state reload complete")
 
-            // Re-establish database connection if it was released during NSE handshake.
-            // The nseWillClose handler sets mlsDatabase = nil; we need it back for
-            // the data source's loadMessages() which reads via appState.mlsDatabase.
-            if mlsDatabase == nil {
-                do {
-                    let database = try await MLSGRDBManager.shared.getDatabasePool(for: userDID)
-                    mlsDatabase = database
-                    logger.info("✅ [AppState] Re-established MLS database after NSE handshake")
-                } catch {
-                    logger.error("❌ [AppState] Failed to re-establish MLS database: \(error.localizedDescription)")
-                }
-            }
-
-            // Also reload conversations to pick up any new messages decrypted by NSE
-            // This updates the UI with messages the NSE may have stored in the database
-            await loadMLSConversations()
-            logger.info("✅ [AppState] MLS conversations reloaded after state sync")
-
-            // Signal active chat views to refresh messages from the database.
-            // Without this, the conversation list updates but the open chat detail
-            // view never re-reads the DB to pick up NSE-decrypted messages.
-            nseStateReloadTrigger += 1
+            await reloadMLSProjectionFromDisk()
         } else {
             logger.debug("⏭️ [AppState] No MLS manager - skipping state reload")
         }
+    }
+
+    /// Reload only Catbird's GRDB-backed presentation state after the authoritative
+    /// manager resume transaction has refreshed Core state and released MLS gates.
+    @MainActor
+    func reloadMLSProjectionFromDisk() async {
+        logger.info("🔄 [AppState] Reloading MLS UI projection from disk")
+
+        // Re-establish database connection if it was released during NSE handshake.
+        // The nseWillClose handler sets mlsDatabase = nil; we need it back for
+        // the data source's loadMessages() which reads via appState.mlsDatabase.
+        if mlsDatabase == nil {
+            do {
+                let database = try await MLSGRDBManager.shared.getDatabasePool(for: userDID)
+                mlsDatabase = database
+                logger.info("✅ [AppState] Re-established MLS database after NSE handshake")
+            } catch {
+                logger.error("❌ [AppState] Failed to re-establish MLS database: \(error.localizedDescription)")
+            }
+        }
+
+        // Reload conversations to pick up any new messages decrypted by NSE.
+        await loadMLSConversations()
+        logger.info("✅ [AppState] MLS conversations reloaded after state sync")
+
+        // Signal active chat views to refresh messages from the database.
+        // Without this, the conversation list updates but the open chat detail
+        // view never re-reads the DB to pick up NSE-decrypted messages.
+        nseStateReloadTrigger += 1
     }
 
     /// Release MLS database readers to allow NSE to perform a clean checkpoint.

--- a/Catbird/Core/State/AppStateManager.swift
+++ b/Catbird/Core/State/AppStateManager.swift
@@ -49,6 +49,12 @@ final class AppStateManager {
 
   private let logger = Logger(subsystem: "blue.catbird", category: "AppStateManager")
 
+  /// Stable storage for the exact lifecycle owner used before an MLS manager exists.
+  /// The owner rotates per suspension so a stale foreground task cannot acquire a
+  /// capability for a newer background signal that arrived before its Core call.
+  @ObservationIgnored
+  private(set) var contextFreeMLSSuspensionOwner = MLSContextFreeLifecycleSuspensionOwner()
+
   /// The authentication manager (owned by AppStateManager)
   private let authManager = AuthenticationManager()
 
@@ -155,6 +161,14 @@ final class AppStateManager {
     }
     
     Task { await MLSClient.shared.setStorageMaintenanceCoordinator(self) }
+  }
+
+  /// Starts a new context-free suspension with a distinct opaque Core owner.
+  /// This synchronous MainActor operation publishes the owner before closing the gate.
+  func beginContextFreeMLSSuspension(reason: String) {
+    let owner = MLSContextFreeLifecycleSuspensionOwner()
+    contextFreeMLSSuspensionOwner = owner
+    owner.markSuspensionInProgress(reason: reason)
   }
 
   /// Initialize the app - check for saved session and transition to appropriate state

--- a/Catbird/Services/MLS/MLSBackgroundRefreshManager.swift
+++ b/Catbird/Services/MLS/MLSBackgroundRefreshManager.swift
@@ -11,6 +11,94 @@ import CatbirdMLSCore
 import Foundation
 import OSLog
 
+enum MLSBackgroundRefreshCloseOutcome: Equatable {
+  case closed
+  case preparationFailed
+  case rustPathUnavailable
+  case expired
+}
+
+final class MLSBackgroundRefreshTerminationState: @unchecked Sendable {
+  private let lock = NSLock()
+  private var expired = false
+  private var normalCloseClaimed = false
+  private var grdbEndClaimed = false
+  private var taskCompletionClaimed = false
+
+  var didExpire: Bool {
+    lock.withLock { expired }
+  }
+
+  func claimExpiration() -> Bool {
+    lock.withLock {
+      guard !expired, !normalCloseClaimed, !taskCompletionClaimed else { return false }
+      expired = true
+      return true
+    }
+  }
+
+  func claimNormalClose() -> Bool {
+    lock.withLock {
+      guard !expired, !normalCloseClaimed else { return false }
+      normalCloseClaimed = true
+      return true
+    }
+  }
+
+  func claimGRDBEnd() -> Bool {
+    lock.withLock {
+      guard !grdbEndClaimed else { return false }
+      grdbEndClaimed = true
+      return true
+    }
+  }
+
+  func claimTaskCompletion() -> Bool {
+    lock.withLock {
+      guard !taskCompletionClaimed else { return false }
+      taskCompletionClaimed = true
+      return true
+    }
+  }
+}
+
+@MainActor
+enum MLSBackgroundRefreshCloseCoordinator {
+  static func run(
+    state: MLSBackgroundRefreshTerminationState,
+    suspendManager: @MainActor () -> Bool,
+    prepareRustRuntime: @MainActor () async -> Bool,
+    closePreparedRuntime: @MainActor () -> Void
+  ) async -> MLSBackgroundRefreshCloseOutcome {
+    guard !state.didExpire else { return .expired }
+    guard suspendManager() else { return .rustPathUnavailable }
+    guard !state.didExpire else { return .expired }
+    guard await prepareRustRuntime() else {
+      return state.didExpire ? .expired : .preparationFailed
+    }
+    guard state.claimNormalClose() else { return .expired }
+    closePreparedRuntime()
+    return .closed
+  }
+}
+
+private func markBackgroundRefreshRustRuntimeClosedSynchronously(
+  manager: MLSConversationManager,
+  reason: String
+) {
+  if Thread.isMainThread {
+    MainActor.assumeIsolated {
+      manager.markRustRuntimeClosedForSuspend(reason: reason)
+    }
+  } else {
+    DispatchQueue.main.sync {
+      MainActor.assumeIsolated {
+        manager.markRustRuntimeClosedForSuspend(reason: reason)
+      }
+    }
+  }
+}
+
 /// Manages automatic background replenishment of MLS key packages
 /// Uses iOS BGTaskScheduler to periodically check and upload key packages when running low
 @available(iOS 13.0, *)
@@ -24,6 +112,13 @@ actor MLSBackgroundRefreshManager {
   private var isRegistered = false
 
   private init() {}
+
+  nonisolated static func shouldDeferForLifecycleSuspension(
+    clientSuspended: Bool,
+    coreSuspended: Bool
+  ) -> Bool {
+    clientSuspended || coreSuspended
+  }
 
   // MARK: - Public API
 
@@ -95,59 +190,38 @@ actor MLSBackgroundRefreshManager {
     logger.info("Background refresh starting")
     defer { scheduleBackgroundRefresh() }
 
-    // BGTasks run while the app lifecycle is backgrounded; allow MLS contexts to be created for this work.
-    MLSClient.clearSuspensionFlag(reason: "MLS BGTask \(Self.taskIdentifier)")
-    MLSCoreContext.clearSuspensionFlag()
-
-    // RAII background task assertion — auto-released on scope exit.
-    // The expiration handler must interrupt in-flight SQLCipher work: Swift Task
-    // cancellation is cooperative and a blocking Rust FFI call never observes it,
-    // so without sqlite3_interrupt the process suspends mid-fsync → 0xdead10cc.
-    let bgTask = CatbirdBackgroundTask(name: "MLS BGTask \(Self.taskIdentifier)") {
-      MLSClient.markSuspensionInProgress(reason: "MLS BGTask assertion expired")
-      MLSCoreContext.markSuspensionInProgress()
-      MLSClient.interruptAllContexts()
-      MLSCoreContext.interruptAllContexts()
+    // A BGTask is never authorized to reopen lifecycle MLS gates. Foreground resume is
+    // the only transaction that may refresh authoritative state and release them.
+    guard !Self.shouldDeferForLifecycleSuspension(
+      clientSuspended: MLSClient.isSuspensionInProgress,
+      coreSuspended: MLSCoreContext.isSuspensionInProgress
+    ) else {
+      logger.warning("Background refresh deferred while MLS lifecycle suspension is active")
+      task.setTaskCompleted(success: false)
+      return
     }
-    defer { bgTask.end() }
+
+    guard let appState = await getAppState() else {
+      logger.error("Background refresh failed: AppState not available")
+      task.setTaskCompleted(success: false)
+      return
+    }
+    guard let manager = await appState.getMLSConversationManager() else {
+      logger.warning("Background refresh skipped: MLS not initialized")
+      task.setTaskCompleted(success: true)
+      return
+    }
 
     // While running in background, ensure GRDB connections are resumed for the duration
     // of this task, and re-suspended once it completes to avoid 0xdead10cc termination.
     GRDBSuspensionCoordinator.beginBackgroundWork(reason: "MLS BGTask \(Self.taskIdentifier)")
-
-    // One-shot cleanup: must run BEFORE setTaskCompleted (iOS may suspend the
-    // process immediately after task completion), with the defer as a backstop
-    // for early-exit/throw paths. One-shot because endBackgroundWork is
-    // refcounted — a double call would steal a unit from concurrent work.
-    var cleanedUp = false
-    func closeContextsAndSuspend() {
-      guard !cleanedUp else { return }
-      cleanedUp = true
-      // Ensure Rust UniFFI contexts are closed before we re-suspend, or iOS may kill us (0xdead10cc).
-      MLSClient.emergencyCloseAllContexts(reason: "MLS BGTask complete")
-      MLSCoreContext.emergencyCloseAllContexts()
-      GRDBSuspensionCoordinator.endBackgroundWork(reason: "MLS BGTask \(Self.taskIdentifier)")
-    }
-    defer { closeContextsAndSuspend() }
+    let terminationState = MLSBackgroundRefreshTerminationState()
 
     let logger = self.logger
-    let refreshWork = Task<Bool, Never> { [weak self] in
-      guard let self else { return false }
-
-      guard let appState = await self.getAppState() else {
-        logger.error("Background refresh failed: AppState not available")
-        return false
-      }
-
-      // Get MLS conversation manager
-      guard let mlsManager = await appState.getMLSConversationManager() else {
-        logger.warning("Background refresh skipped: MLS not initialized")
-        return true
-      }
-
+    let refreshWork = Task<Bool, Never> {
       do {
         try Task.checkCancellation()
-        try await mlsManager.smartRefreshKeyPackages(maxGeneratedPackages: 5)
+        try await manager.smartRefreshKeyPackages(maxGeneratedPackages: 5)
         try Task.checkCancellation()
         logger.info("Background refresh completed successfully")
         return true
@@ -160,24 +234,57 @@ actor MLSBackgroundRefreshManager {
       }
     }
 
-    task.expirationHandler = {
-      logger.warning("Background task expired before completion; interrupting MLS FFI and canceling refresh")
-      // Arm the suspension machinery BEFORE the cooperative cancel: the
-      // suspension flag makes runFFI and the Rust check_suspended() bail-outs
-      // reject the rest of the batch, and sqlite3_interrupt aborts the
-      // statement currently holding the SQLCipher file lock. Task.cancel()
-      // alone never reaches a blocking FFI call (0xdead10cc root cause).
-      MLSClient.markSuspensionInProgress(reason: "MLS BGTask expired")
-      MLSCoreContext.markSuspensionInProgress()
-      MLSClient.interruptAllContexts()
-      MLSCoreContext.interruptAllContexts()
+    let expire: @Sendable () -> Void = {
+      if terminationState.claimExpiration() {
+        logger.warning("Background task expired; force-closing MLS runtime exactly once")
+        MLSClient.markSuspensionInProgress(reason: "MLS BGTask expired")
+        MLSCoreContext.markSuspensionInProgress()
+        MLSClient.interruptAllContexts()
+        MLSCoreContext.interruptAllContexts()
+        MLSClient.emergencyCloseAllContexts(reason: "MLS BGTask expired")
+        MLSCoreContext.emergencyCloseAllContexts()
+        markBackgroundRefreshRustRuntimeClosedSynchronously(
+          manager: manager,
+          reason: "MLS BGTask expired"
+        )
+        if terminationState.claimGRDBEnd() {
+          GRDBSuspensionCoordinator.endBackgroundWork(reason: "MLS BGTask \(Self.taskIdentifier) expired")
+        }
+        if terminationState.claimTaskCompletion() {
+          task.setTaskCompleted(success: false)
+        }
+      }
       refreshWork.cancel()
     }
+    let bgTask = CatbirdBackgroundTask(
+      name: "MLS BGTask \(Self.taskIdentifier)",
+      expirationHandler: expire
+    )
+    defer { bgTask.end() }
+    task.expirationHandler = expire
 
-    let success = await refreshWork.value
+    let refreshSucceeded = await refreshWork.value
+    let closeOutcome = await MLSBackgroundRefreshCloseCoordinator.run(
+      state: terminationState,
+      suspendManager: {
+        manager.suspendMLSOperations()
+      },
+      prepareRustRuntime: {
+        await manager.prepareRustRuntimeForSuspensionAfterDrain(timeout: 5)
+      },
+      closePreparedRuntime: {
+        MLSClient.emergencyCloseAllContexts(reason: "MLS BGTask prepared completion")
+        MLSCoreContext.emergencyCloseAllContexts()
+        manager.markRustRuntimeClosedForSuspend(reason: "MLS BGTask prepared completion")
+      }
+    )
 
-    closeContextsAndSuspend()
-    task.setTaskCompleted(success: success)
+    if terminationState.claimGRDBEnd() {
+      GRDBSuspensionCoordinator.endBackgroundWork(reason: "MLS BGTask \(Self.taskIdentifier)")
+    }
+    if terminationState.claimTaskCompletion() {
+      task.setTaskCompleted(success: refreshSucceeded && closeOutcome == .closed)
+    }
   }
 
   // MARK: - Helper Methods

--- a/Catbird/Services/MLS/MLSBackgroundRefreshManager.swift
+++ b/Catbird/Services/MLS/MLSBackgroundRefreshManager.swift
@@ -238,11 +238,9 @@ actor MLSBackgroundRefreshManager {
       if terminationState.claimExpiration() {
         logger.warning("Background task expired; force-closing MLS runtime exactly once")
         MLSClient.markSuspensionInProgress(reason: "MLS BGTask expired")
-        MLSCoreContext.markSuspensionInProgress()
         MLSClient.interruptAllContexts()
         MLSCoreContext.interruptAllContexts()
         MLSClient.emergencyCloseAllContexts(reason: "MLS BGTask expired")
-        MLSCoreContext.emergencyCloseAllContexts()
         markBackgroundRefreshRustRuntimeClosedSynchronously(
           manager: manager,
           reason: "MLS BGTask expired"
@@ -274,7 +272,6 @@ actor MLSBackgroundRefreshManager {
       },
       closePreparedRuntime: {
         MLSClient.emergencyCloseAllContexts(reason: "MLS BGTask prepared completion")
-        MLSCoreContext.emergencyCloseAllContexts()
         manager.markRustRuntimeClosedForSuspend(reason: "MLS BGTask prepared completion")
       }
     )

--- a/Catbird/Services/MLS/NSENotificationProcessingLeases.swift
+++ b/Catbird/Services/MLS/NSENotificationProcessingLeases.swift
@@ -1,0 +1,221 @@
+import Foundation
+
+@MainActor
+final class NSENotificationProcessingLeases {
+  struct Lease: Hashable {
+    let id: UUID
+    let startsNewGeneration: Bool
+    let recipientDID: String
+  }
+
+  struct OrdinaryCleanupClaim: Hashable {
+    let id: UUID
+    let generationID: UUID
+  }
+
+  struct AppStopCleanupClaim: Hashable {
+    let id: UUID
+    let generationID: UUID
+    let recipientDIDs: Set<String>
+  }
+
+  enum ReleaseDecision: Equatable {
+    case stillProcessing
+    case performCleanup(OrdinaryCleanupClaim)
+    case cleanupAlreadyPerformed
+    case cleanupOwnedElsewhere
+  }
+
+  enum AppStopDecision: Equatable {
+    case performCleanup(AppStopCleanupClaim)
+    case cleanupAlreadyPerformed
+  }
+
+  private var generationID = UUID()
+  private var activeLeases: [UUID: String] = [:]
+  private var generationRecipientDIDs: Set<String> = []
+  private var cleanupInProgress = false
+  private var cleanupCompletedForGeneration = true
+  private var expirationCleanupClaimed = false
+  private var ordinaryCleanupClaim: OrdinaryCleanupClaim?
+  private var ordinaryCleanupClosing = false
+  private var appStopCleanupClaim: AppStopCleanupClaim?
+  private var appStopCleanupClosing = false
+  private var appStopPending = false
+  private var acquisitionWaiters: [CheckedContinuation<Void, Never>] = []
+  private var appStopWaiters: [CheckedContinuation<AppStopDecision, Never>] = []
+
+  var activeRecipientDIDs: Set<String> {
+    Set(activeLeases.values)
+  }
+
+  func acquire(recipientDID: String) async -> Lease {
+    while cleanupInProgress || appStopPending {
+      await withCheckedContinuation { continuation in
+        acquisitionWaiters.append(continuation)
+      }
+    }
+
+    let startsNewGeneration = activeLeases.isEmpty && cleanupCompletedForGeneration
+    if startsNewGeneration {
+      generationID = UUID()
+      generationRecipientDIDs.removeAll(keepingCapacity: true)
+      cleanupCompletedForGeneration = false
+      expirationCleanupClaimed = false
+      ordinaryCleanupClaim = nil
+      ordinaryCleanupClosing = false
+      appStopCleanupClaim = nil
+      appStopCleanupClosing = false
+    }
+
+    let lease = Lease(
+      id: UUID(),
+      startsNewGeneration: startsNewGeneration,
+      recipientDID: recipientDID
+    )
+    activeLeases[lease.id] = recipientDID
+    generationRecipientDIDs.insert(recipientDID)
+    return lease
+  }
+
+  func release(_ lease: Lease) -> ReleaseDecision {
+    guard activeLeases.removeValue(forKey: lease.id) != nil else {
+      return .cleanupAlreadyPerformed
+    }
+    guard activeLeases.isEmpty else {
+      return .stillProcessing
+    }
+
+    if expirationCleanupClaimed {
+      completeCleanupGeneration()
+      return .cleanupAlreadyPerformed
+    }
+
+    if appStopPending {
+      activateAppStopCleanup()
+      return .cleanupOwnedElsewhere
+    }
+
+    guard !cleanupCompletedForGeneration else {
+      return .cleanupAlreadyPerformed
+    }
+
+    let claim = OrdinaryCleanupClaim(id: UUID(), generationID: generationID)
+    ordinaryCleanupClaim = claim
+    ordinaryCleanupClosing = false
+    cleanupInProgress = true
+    return .performCleanup(claim)
+  }
+
+  func ordinaryCleanupIsCurrent(_ claim: OrdinaryCleanupClaim) -> Bool {
+    ordinaryCleanupClaim == claim && !cleanupCompletedForGeneration
+  }
+
+  func beginOrdinaryClose(_ claim: OrdinaryCleanupClaim) -> Bool {
+    guard ordinaryCleanupIsCurrent(claim) else { return false }
+    ordinaryCleanupClosing = true
+    return true
+  }
+
+  func finishOrdinaryCleanup(_ claim: OrdinaryCleanupClaim) {
+    guard ordinaryCleanupClaim == claim else { return }
+    completeCleanupGeneration()
+  }
+
+  func claimExpirationCleanup() -> Bool {
+    guard !expirationCleanupClaimed else { return false }
+    guard !cleanupCompletedForGeneration else { return false }
+
+    expirationCleanupClaimed = true
+    cleanupInProgress = true
+    if ordinaryCleanupClosing || appStopCleanupClosing {
+      return false
+    }
+    ordinaryCleanupClaim = nil
+    appStopCleanupClaim = nil
+    return true
+  }
+
+  func finishExpirationCleanupIfIdle() {
+    guard activeLeases.isEmpty else { return }
+    completeCleanupGeneration()
+  }
+
+  func requestAppStopCleanup() async -> AppStopDecision {
+    guard !cleanupCompletedForGeneration else {
+      return .cleanupAlreadyPerformed
+    }
+
+    appStopPending = true
+    if activeLeases.isEmpty && !cleanupInProgress {
+      return makeAppStopCleanupDecision()
+    }
+
+    return await withCheckedContinuation { continuation in
+      appStopWaiters.append(continuation)
+    }
+  }
+
+  func finishAppStopCleanup(_ claim: AppStopCleanupClaim) {
+    guard appStopCleanupClaim == claim else { return }
+    completeCleanupGeneration()
+  }
+
+  func appStopCleanupIsCurrent(_ claim: AppStopCleanupClaim) -> Bool {
+    appStopCleanupClaim == claim && !cleanupCompletedForGeneration
+  }
+
+  func beginAppStopClose(_ claim: AppStopCleanupClaim) -> Bool {
+    guard appStopCleanupIsCurrent(claim) else { return false }
+    appStopCleanupClosing = true
+    return true
+  }
+
+  private func activateAppStopCleanup() {
+    let decision = makeAppStopCleanupDecision()
+    guard !appStopWaiters.isEmpty else { return }
+    let owner = appStopWaiters.removeFirst()
+    owner.resume(returning: decision)
+    let remaining = appStopWaiters
+    appStopWaiters.removeAll(keepingCapacity: true)
+    for waiter in remaining {
+      waiter.resume(returning: .cleanupAlreadyPerformed)
+    }
+  }
+
+  private func makeAppStopCleanupDecision() -> AppStopDecision {
+    cleanupInProgress = true
+    appStopPending = false
+    let claim = AppStopCleanupClaim(
+      id: UUID(),
+      generationID: generationID,
+      recipientDIDs: generationRecipientDIDs
+    )
+    appStopCleanupClaim = claim
+    appStopCleanupClosing = false
+    return .performCleanup(claim)
+  }
+
+  private func completeCleanupGeneration() {
+    cleanupCompletedForGeneration = true
+    cleanupInProgress = false
+    expirationCleanupClaimed = expirationCleanupClaimed || ordinaryCleanupClosing
+    ordinaryCleanupClaim = nil
+    ordinaryCleanupClosing = false
+    appStopCleanupClaim = nil
+    appStopCleanupClosing = false
+    appStopPending = false
+
+    let stopWaiters = appStopWaiters
+    appStopWaiters.removeAll(keepingCapacity: true)
+    for waiter in stopWaiters {
+      waiter.resume(returning: .cleanupAlreadyPerformed)
+    }
+
+    let waiters = acquisitionWaiters
+    acquisitionWaiters.removeAll(keepingCapacity: true)
+    for waiter in waiters {
+      waiter.resume()
+    }
+  }
+}

--- a/CatbirdTests/MLSAccountSwitchSuspensionContractTests.swift
+++ b/CatbirdTests/MLSAccountSwitchSuspensionContractTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @MainActor
 final class MLSAccountSwitchSuspensionContractTests: XCTestCase {
-    func testScenePhaseUsesManagerOwnedSuspensionWithOwnerlessFallback() throws {
+    func testScenePhaseUsesManagerOwnedSuspensionWithContextFreeFallback() throws {
         let source = try appSource(relativePath: "Catbird/App/CatbirdApp.swift")
         let body = try XCTUnwrap(
             appFunctionBody(
@@ -31,7 +31,7 @@ final class MLSAccountSwitchSuspensionContractTests: XCTestCase {
         XCTAssertFalse(managerBranch.contains("MLSClient.markSuspensionInProgress("))
         XCTAssertTrue(
             ownerlessBranch.contains(
-                "MLSClient.markSuspensionInProgress(reason: \"scenePhase → \\(String(describing: newPhase))\")"
+                "appStateManager.beginContextFreeMLSSuspension("
             )
         )
         XCTAssertFalse(ownerlessBranch.contains("manager.suspendMLSOperations()"))
@@ -41,10 +41,7 @@ final class MLSAccountSwitchSuspensionContractTests: XCTestCase {
             ).count - 1,
             1
         )
-        XCTAssertEqual(
-            body.components(separatedBy: "MLSClient.markSuspensionInProgress(").count - 1,
-            1
-        )
+        XCTAssertFalse(body.contains("MLSCoreContext.markSuspensionInProgress()"))
     }
 
     func testOnlyAccountSwitchShutdownConsumesSuspensionAbandonmentAuthorization() throws {

--- a/CatbirdTests/MLSAccountSwitchSuspensionContractTests.swift
+++ b/CatbirdTests/MLSAccountSwitchSuspensionContractTests.swift
@@ -1,0 +1,137 @@
+@testable import Catbird
+import XCTest
+
+@MainActor
+final class MLSAccountSwitchSuspensionContractTests: XCTestCase {
+    func testScenePhaseUsesManagerOwnedSuspensionWithOwnerlessFallback() throws {
+        let source = try appSource(relativePath: "Catbird/App/CatbirdApp.swift")
+        let body = try XCTUnwrap(
+            appFunctionBody(
+                signature: "func handleScenePhaseChange(from oldPhase: ScenePhase, to newPhase: ScenePhase)",
+                in: source
+            )
+        )
+        let managerBranch = try XCTUnwrap(
+            appFunctionBody(
+                signature: "if let manager = appStateManager.lifecycle.appState?.mlsConversationManager",
+                in: body
+            )
+        )
+        let managerBranchRange = try XCTUnwrap(body.range(of: managerBranch))
+        let ownerlessBranch = try XCTUnwrap(
+            appFunctionBody(
+                signature: "else",
+                in: String(body[managerBranchRange.upperBound...])
+            )
+        )
+
+        XCTAssertTrue(
+            managerBranch.contains("rustPathAvailable = manager.suspendMLSOperations()")
+        )
+        XCTAssertFalse(managerBranch.contains("MLSClient.markSuspensionInProgress("))
+        XCTAssertTrue(
+            ownerlessBranch.contains(
+                "MLSClient.markSuspensionInProgress(reason: \"scenePhase → \\(String(describing: newPhase))\")"
+            )
+        )
+        XCTAssertFalse(ownerlessBranch.contains("manager.suspendMLSOperations()"))
+        XCTAssertEqual(
+            body.components(
+                separatedBy: "rustPathAvailable = manager.suspendMLSOperations()"
+            ).count - 1,
+            1
+        )
+        XCTAssertEqual(
+            body.components(separatedBy: "MLSClient.markSuspensionInProgress(").count - 1,
+            1
+        )
+    }
+
+    func testOnlyAccountSwitchShutdownConsumesSuspensionAbandonmentAuthorization() throws {
+        let source = try appSource(relativePath: "Catbird/Core/State/AppState.swift")
+        let cleanupBody = try XCTUnwrap(
+            appFunctionBody(signature: "func cleanup()", in: source)
+        )
+        let accountSwitchBody = try XCTUnwrap(
+            appFunctionBody(signature: "private func reinitializeMLSAfterSwitch() async", in: source)
+        )
+        let normalizedAccountSwitchBody = normalizedWhitespace(accountSwitchBody)
+
+        XCTAssertTrue(cleanupBody.contains("await manager.shutdown()"))
+        XCTAssertFalse(cleanupBody.contains("authorizeSuspensionAbandonmentForAccountSwitch"))
+        XCTAssertFalse(cleanupBody.contains("accountSwitchSuspensionAuthorization"))
+        let suspendRange = try XCTUnwrap(
+            normalizedAccountSwitchBody.range(
+                of: "let rustAvailable = oldManager.suspendMLSOperations()"
+            )
+        )
+        let authorizationRange = try XCTUnwrap(
+            normalizedAccountSwitchBody.range(
+                of: "guard let authorization = oldManager.authorizeSuspensionAbandonmentForAccountSwitch()"
+            )
+        )
+        let shutdownRange = try XCTUnwrap(
+            normalizedAccountSwitchBody.range(
+                of: "oldManager.shutdown(accountSwitchSuspensionAuthorization: authorization)"
+            )
+        )
+        XCTAssertLessThan(suspendRange.lowerBound, authorizationRange.lowerBound)
+        XCTAssertLessThan(authorizationRange.lowerBound, shutdownRange.lowerBound)
+        XCTAssertFalse(accountSwitchBody.contains("guard rustAvailable"))
+        XCTAssertFalse(accountSwitchBody.contains("prepareRustRuntimeForSuspensionAfterDrain"))
+        XCTAssertFalse(accountSwitchBody.contains("emergencyCloseAllContexts"))
+        XCTAssertFalse(accountSwitchBody.contains("markRustRuntimeClosedForSuspend"))
+        XCTAssertEqual(
+            source.components(
+                separatedBy: "authorizeSuspensionAbandonmentForAccountSwitch()"
+            ).count - 1,
+            1
+        )
+        XCTAssertEqual(
+            source.components(
+                separatedBy: "accountSwitchSuspensionAuthorization: authorization"
+            ).count - 1,
+            1
+        )
+    }
+
+    private func appSource(relativePath: String) throws -> String {
+        let repositoryRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        return try String(
+            contentsOf: repositoryRoot.appendingPathComponent(relativePath),
+            encoding: .utf8
+        )
+    }
+
+    private func normalizedWhitespace(_ source: String) -> String {
+        source.split(whereSeparator: \Character.isWhitespace).joined(separator: " ")
+    }
+
+    private func appFunctionBody(signature: String, in source: String) -> String? {
+        guard let signatureRange = source.range(of: signature),
+              let openingBrace = source[signatureRange.upperBound...].firstIndex(of: "{")
+        else {
+            return nil
+        }
+
+        var depth = 0
+        var cursor = openingBrace
+        while cursor < source.endIndex {
+            switch source[cursor] {
+            case "{":
+                depth += 1
+            case "}":
+                depth -= 1
+                if depth == 0 {
+                    return String(source[openingBrace ... cursor])
+                }
+            default:
+                break
+            }
+            cursor = source.index(after: cursor)
+        }
+        return nil
+    }
+}

--- a/CatbirdTests/MLSForegroundResumeContractTests.swift
+++ b/CatbirdTests/MLSForegroundResumeContractTests.swift
@@ -527,6 +527,9 @@ final class MLSForegroundResumeContractTests: XCTestCase {
 
     func testBackgroundBeforeFirstChatUsesOwnedContextFreeSuspensionLifecycle() throws {
         let appSource = try source(relativePath: "Catbird/App/CatbirdApp.swift")
+        let appStateManagerSource = try source(
+            relativePath: "Catbird/Core/State/AppStateManager.swift"
+        )
         let sceneHandler = try XCTUnwrap(
             functionBody(
                 signature: "func handleScenePhaseChange(from oldPhase: ScenePhase, to newPhase: ScenePhase)",
@@ -541,6 +544,15 @@ final class MLSForegroundResumeContractTests: XCTestCase {
         )
 
         XCTAssertTrue(
+            appStateManagerSource.contains(
+                "var contextFreeMLSSuspensionOwner = "
+                    + "MLSContextFreeLifecycleSuspensionOwner()"
+            )
+        )
+        XCTAssertTrue(
+            appStateManagerSource.contains("func beginContextFreeMLSSuspension(")
+        )
+        XCTAssertFalse(
             appSource.contains(
                 "private let contextFreeMLSSuspensionOwner = "
                     + "MLSContextFreeLifecycleSuspensionOwner()"
@@ -548,21 +560,172 @@ final class MLSForegroundResumeContractTests: XCTestCase {
         )
         XCTAssertTrue(
             sceneHandler.contains(
-                "contextFreeMLSSuspensionOwner.markSuspensionInProgress("
+                "appStateManager.beginContextFreeMLSSuspension("
             )
         )
         XCTAssertTrue(
             foregroundResume.contains(
-                "await contextFreeMLSSuspensionOwner.resumeSuspensionIfOwnedAndContextFree()"
+                "appStateManager.contextFreeMLSSuspensionOwner"
             )
         )
+        XCTAssertTrue(foregroundResume.contains(".resumeSuspensionIfOwnedAndContextFree()"))
         XCTAssertTrue(
             foregroundResume.contains(
-                "MLSForegroundResumeCoordinator.isCurrentActiveTransition(transitionToken)"
+                "MLSForegroundResumeCoordinator."
+                    + "isCurrentActiveTransition(transitionToken)"
             )
         )
         XCTAssertFalse(foregroundResume.contains("MLSClient.clearSuspension"))
         XCTAssertFalse(foregroundResume.contains("MLSCoreContext.clearSuspensionFlag"))
+    }
+
+    func testCurrentContextFreeResumeReleasesExactlyOnce() async {
+        var releaseCount = 0
+
+        let outcome = await MLSForegroundResumeCoordinator.runContextFree(
+            resumeStillCurrent: { true },
+            releaseOwnedSuspension: {
+                releaseCount += 1
+                return true
+            }
+        )
+
+        XCTAssertEqual(outcome, .resumed)
+        XCTAssertEqual(releaseCount, 1)
+    }
+
+    func testStaleContextFreeResumeDoesNotInvokeOwnerRelease() async {
+        var releaseCount = 0
+
+        let outcome = await MLSForegroundResumeCoordinator.runContextFree(
+            resumeStillCurrent: { false },
+            releaseOwnedSuspension: {
+                releaseCount += 1
+                return true
+            }
+        )
+
+        XCTAssertEqual(outcome, .staleTransition)
+        XCTAssertEqual(releaseCount, 0)
+    }
+
+    func testNewerBackgroundDuringContextFreeReleaseKeepsAdmissionClosed() async {
+        let foregroundToken = MLSForegroundResumeCoordinator.recordSceneTransition(
+            to: .active
+        )
+        let releaseStarted = expectation(description: "context-free release started")
+        var releaseContinuation: CheckedContinuation<Void, Never>?
+        var releaseCount = 0
+        var clientGateClosed = true
+        var coreGateClosed = true
+        let capturedOwner = UUID()
+        var currentOwner = capturedOwner
+
+        let resumeTask = Task { @MainActor in
+            await MLSForegroundResumeCoordinator.runContextFree(
+                resumeStillCurrent: {
+                    MLSForegroundResumeCoordinator.isCurrentActiveTransition(
+                        foregroundToken
+                    )
+                },
+                releaseOwnedSuspension: {
+                    releaseCount += 1
+                    releaseStarted.fulfill()
+                    await withCheckedContinuation { continuation in
+                        releaseContinuation = continuation
+                    }
+
+                    // Models Core's opaque owner check at capability capture.
+                    // The superseding transition rotates the owner before this
+                    // stale release resumes.
+                    guard capturedOwner == currentOwner else {
+                        return false
+                    }
+                    clientGateClosed = false
+                    coreGateClosed = false
+                    return true
+                }
+            )
+        }
+
+        await fulfillment(of: [releaseStarted])
+        let backgroundToken = MLSForegroundResumeCoordinator.recordSceneTransition(
+            to: .background
+        )
+        currentOwner = UUID()
+        clientGateClosed = true
+        coreGateClosed = true
+        releaseContinuation?.resume()
+
+        let outcome = await resumeTask.value
+        XCTAssertEqual(outcome, .staleTransition)
+        XCTAssertEqual(releaseCount, 1)
+        XCTAssertTrue(clientGateClosed)
+        XCTAssertTrue(coreGateClosed)
+        XCTAssertTrue(
+            MLSForegroundResumeCoordinator.isCurrentTransition(
+                backgroundToken,
+                expectedPhase: .background
+            )
+        )
+    }
+
+    func testRotatedOwnerRejectsStaleReleaseBeforeCoreCapabilityCapture() async {
+        let staleForegroundOwner = MLSContextFreeLifecycleSuspensionOwner()
+        staleForegroundOwner.markSuspensionInProgress(reason: "older foreground owner")
+
+        // The app-level active precheck has already passed. A newer background
+        // transition now rotates the stable store to a distinct opaque owner.
+        let newerBackgroundOwner = MLSContextFreeLifecycleSuspensionOwner()
+        newerBackgroundOwner.markSuspensionInProgress(reason: "newer background owner")
+
+        let staleReleased =
+            await staleForegroundOwner.resumeSuspensionIfOwnedAndContextFree()
+        XCTAssertFalse(staleReleased)
+        XCTAssertTrue(MLSClient.isSuspensionInProgress)
+        XCTAssertTrue(MLSCoreContext.isSuspensionInProgress)
+
+        let newerReleased =
+            await newerBackgroundOwner.resumeSuspensionIfOwnedAndContextFree()
+        XCTAssertTrue(newerReleased)
+        XCTAssertFalse(MLSClient.isSuspensionInProgress)
+        XCTAssertFalse(MLSCoreContext.isSuspensionInProgress)
+    }
+
+    func testManagerResumePathDoesNotInvokeContextFreeRelease() throws {
+        let appSource = try source(relativePath: "Catbird/App/CatbirdApp.swift")
+        let foregroundResume = try XCTUnwrap(
+            functionBody(
+                signature: "private func resumeMLSAfterReturningToForeground("
+                    + "transitionToken: UInt64) async",
+                in: appSource
+            )
+        )
+        let contextFreeBranch = try XCTUnwrap(
+            functionBody(signature: "guard let manager else", in: foregroundResume)
+        )
+        let capturedOwner = try XCTUnwrap(
+            contextFreeBranch.range(
+                of: "let contextFreeSuspensionOwner = "
+                    + "appStateManager.contextFreeMLSSuspensionOwner"
+            )
+        )
+        let coordinatorCall = try XCTUnwrap(
+            contextFreeBranch.range(
+                of: "MLSForegroundResumeCoordinator.runContextFree("
+            )
+        )
+        XCTAssertLessThan(capturedOwner.lowerBound, coordinatorCall.lowerBound)
+        XCTAssertTrue(
+            contextFreeBranch.contains("contextFreeSuspensionOwner")
+        )
+        XCTAssertTrue(
+            contextFreeBranch.contains(".resumeSuspensionIfOwnedAndContextFree()")
+        )
+        XCTAssertFalse(contextFreeBranch.contains("manager.resumeMLSOperations()"))
+        XCTAssertTrue(
+            foregroundResume.contains("return await manager.resumeMLSOperations()")
+        )
     }
 
     private func source(relativePath: String) throws -> String {

--- a/CatbirdTests/MLSForegroundResumeContractTests.swift
+++ b/CatbirdTests/MLSForegroundResumeContractTests.swift
@@ -276,14 +276,11 @@ final class MLSForegroundResumeContractTests: XCTestCase {
         let clientClose = try XCTUnwrap(
             backgroundCloseBody.range(of: "MLSClient.emergencyCloseAllContexts(")
         )
-        let coreClose = try XCTUnwrap(
-            backgroundCloseBody.range(of: "MLSCoreContext.emergencyCloseAllContexts()")
-        )
         let runtimeMark = try XCTUnwrap(
             backgroundCloseBody.range(of: "manager.markRustRuntimeClosedForSuspend(")
         )
-        XCTAssertLessThan(clientClose.lowerBound, coreClose.lowerBound)
-        XCTAssertLessThan(coreClose.lowerBound, runtimeMark.lowerBound)
+        XCTAssertLessThan(clientClose.lowerBound, runtimeMark.lowerBound)
+        XCTAssertFalse(backgroundCloseBody.contains("MLSCoreContext.emergencyCloseAllContexts()"))
         XCTAssertFalse(backgroundCloseBody.contains("await"))
 
         let expirationBody = try XCTUnwrap(
@@ -422,10 +419,9 @@ final class MLSForegroundResumeContractTests: XCTestCase {
             functionBody(signature: "closePreparedRuntime:", in: body)
         )
         let clientClose = try XCTUnwrap(closeBody.range(of: "MLSClient.emergencyCloseAllContexts("))
-        let coreClose = try XCTUnwrap(closeBody.range(of: "MLSCoreContext.emergencyCloseAllContexts()"))
         let runtimeMark = try XCTUnwrap(closeBody.range(of: "manager.markRustRuntimeClosedForSuspend("))
-        XCTAssertLessThan(clientClose.lowerBound, coreClose.lowerBound)
-        XCTAssertLessThan(coreClose.lowerBound, runtimeMark.lowerBound)
+        XCTAssertLessThan(clientClose.lowerBound, runtimeMark.lowerBound)
+        XCTAssertFalse(closeBody.contains("MLSCoreContext.emergencyCloseAllContexts()"))
         XCTAssertFalse(closeBody.contains("await"))
         XCTAssertTrue(
             body.contains(
@@ -726,6 +722,29 @@ final class MLSForegroundResumeContractTests: XCTestCase {
         XCTAssertTrue(
             foregroundResume.contains("return await manager.resumeMLSOperations()")
         )
+    }
+
+    func testCatbirdConsumersUseOnlyCoupledCoreLifecycleMutators() throws {
+        let consumerPaths = [
+            "Catbird/App/CatbirdApp.swift",
+            "Catbird/Services/MLS/MLSBackgroundRefreshManager.swift",
+            "NotificationServiceExtension/NotificationService.swift",
+        ]
+        let rawCoreMutators = [
+            "MLSCoreContext.markSuspensionInProgress()",
+            "MLSCoreContext.clearSuspensionFlag()",
+            "MLSCoreContext.emergencyCloseAllContexts()",
+        ]
+
+        for path in consumerPaths {
+            let consumerSource = try source(relativePath: path)
+            for rawMutator in rawCoreMutators {
+                XCTAssertFalse(
+                    consumerSource.contains(rawMutator),
+                    "\(path) must not bypass MLSClient with \(rawMutator)"
+                )
+            }
+        }
     }
 
     private func source(relativePath: String) throws -> String {
@@ -1048,13 +1067,14 @@ final class MLSForegroundResumeRaceTests: XCTestCase {
         let ownerBoundSuspend = try XCTUnwrap(
             sceneHandler.range(of: "rustPathAvailable = manager.suspendMLSOperations()")
         )
-        let coreGateClose = try XCTUnwrap(
-            sceneHandler.range(of: "MLSCoreContext.markSuspensionInProgress()")
+        let contextFreeGateClose = try XCTUnwrap(
+            sceneHandler.range(of: "appStateManager.beginContextFreeMLSSuspension(")
         )
         let firstAwaitingTask = try XCTUnwrap(sceneHandler.range(of: "Task { @MainActor in"))
         XCTAssertLessThan(recordTransition.lowerBound, ownerBoundSuspend.lowerBound)
-        XCTAssertLessThan(ownerBoundSuspend.lowerBound, coreGateClose.lowerBound)
-        XCTAssertLessThan(coreGateClose.lowerBound, firstAwaitingTask.lowerBound)
+        XCTAssertLessThan(ownerBoundSuspend.lowerBound, firstAwaitingTask.lowerBound)
+        XCTAssertLessThan(contextFreeGateClose.lowerBound, firstAwaitingTask.lowerBound)
+        XCTAssertFalse(sceneHandler.contains("MLSCoreContext.markSuspensionInProgress()"))
 
         let foregroundToken = MLSForegroundResumeCoordinator.recordSceneTransition(to: .active)
         var managerContinuation: CheckedContinuation<Void, Never>?

--- a/CatbirdTests/MLSForegroundResumeContractTests.swift
+++ b/CatbirdTests/MLSForegroundResumeContractTests.swift
@@ -1,0 +1,974 @@
+@testable import Catbird
+import CatbirdMLSCore
+import SwiftUI
+import XCTest
+
+@MainActor
+final class MLSForegroundResumeContractTests: XCTestCase {
+    private enum TestError: Error {
+        case preparationFailed
+    }
+
+    func testForegroundResumeRunsStorageThenManagerThenProjectionAndBackup() async {
+        var events: [String] = []
+
+        let result = await MLSForegroundResumeCoordinator.run(
+            managerAvailable: true,
+            resumeStillCurrent: { true },
+            prepareStorage: {
+                events.append("prepare")
+            },
+            resumeManager: {
+                events.append("resume")
+                return .resumed
+            },
+            reassertSuspensionAfterStaleResume: {},
+            reloadProjection: {
+                events.append("projection")
+            },
+            performBackup: {
+                events.append("backup")
+            }
+        )
+
+        XCTAssertEqual(result, .resumed)
+        XCTAssertEqual(events, ["prepare", "resume", "projection", "backup"])
+    }
+
+    func testForegroundPreparationFailureLeavesMLSClosedAndShortCircuitsDownstreamWork() async {
+        var events: [String] = []
+
+        let result = await MLSForegroundResumeCoordinator.run(
+            managerAvailable: true,
+            resumeStillCurrent: { true },
+            prepareStorage: {
+                events.append("prepare")
+                throw TestError.preparationFailed
+            },
+            resumeManager: {
+                events.append("resume")
+                return .resumed
+            },
+            reassertSuspensionAfterStaleResume: {},
+            reloadProjection: {
+                events.append("projection")
+            },
+            performBackup: {
+                events.append("backup")
+            }
+        )
+
+        XCTAssertEqual(result, .preparationFailed)
+        XCTAssertEqual(events, ["prepare"])
+    }
+
+    func testFailedManagerResumeSkipsProjectionAndBackup() async {
+        var events: [String] = []
+
+        let result = await MLSForegroundResumeCoordinator.run(
+            managerAvailable: true,
+            resumeStillCurrent: { true },
+            prepareStorage: {
+                events.append("prepare")
+            },
+            resumeManager: {
+                events.append("resume")
+                return .failedStillSuspended
+            },
+            reassertSuspensionAfterStaleResume: {},
+            reloadProjection: {
+                events.append("projection")
+            },
+            performBackup: {
+                events.append("backup")
+            }
+        )
+
+        XCTAssertEqual(result, .failedStillSuspended)
+        XCTAssertEqual(events, ["prepare", "resume"])
+    }
+
+    func testMissingManagerSkipsAllForegroundMLSWork() async {
+        var events: [String] = []
+
+        let result = await MLSForegroundResumeCoordinator.run(
+            managerAvailable: false,
+            resumeStillCurrent: { true },
+            prepareStorage: {
+                events.append("prepare")
+            },
+            resumeManager: {
+                events.append("resume")
+                return .resumed
+            },
+            reassertSuspensionAfterStaleResume: {},
+            reloadProjection: {
+                events.append("projection")
+            },
+            performBackup: {
+                events.append("backup")
+            }
+        )
+
+        XCTAssertEqual(result, .managerUnavailable)
+        XCTAssertEqual(events, [])
+    }
+
+    func testBackgroundTaskDefersForEitherGlobalSuspensionGate() {
+        XCTAssertFalse(
+            MLSBackgroundRefreshManager.shouldDeferForLifecycleSuspension(
+                clientSuspended: false,
+                coreSuspended: false
+            )
+        )
+        XCTAssertTrue(
+            MLSBackgroundRefreshManager.shouldDeferForLifecycleSuspension(
+                clientSuspended: true,
+                coreSuspended: false
+            )
+        )
+        XCTAssertTrue(
+            MLSBackgroundRefreshManager.shouldDeferForLifecycleSuspension(
+                clientSuspended: false,
+                coreSuspended: true
+            )
+        )
+    }
+
+    func testBackgroundRefreshPreparesBeforeNormalClose() async {
+        let state = MLSBackgroundRefreshTerminationState()
+        var events: [String] = []
+
+        let outcome = await MLSBackgroundRefreshCloseCoordinator.run(
+            state: state,
+            suspendManager: {
+                events.append("suspend")
+                return true
+            },
+            prepareRustRuntime: {
+                events.append("prepare")
+                return true
+            },
+            closePreparedRuntime: {
+                events.append("close")
+            }
+        )
+
+        XCTAssertEqual(outcome, .closed)
+        XCTAssertEqual(events, ["suspend", "prepare", "close"])
+    }
+
+    func testBackgroundRefreshPreparationFailureSkipsNormalClose() async {
+        let state = MLSBackgroundRefreshTerminationState()
+        var events: [String] = []
+
+        let outcome = await MLSBackgroundRefreshCloseCoordinator.run(
+            state: state,
+            suspendManager: {
+                events.append("suspend")
+                return true
+            },
+            prepareRustRuntime: {
+                events.append("prepare")
+                return false
+            },
+            closePreparedRuntime: {
+                events.append("close")
+            }
+        )
+
+        XCTAssertEqual(outcome, .preparationFailed)
+        XCTAssertEqual(events, ["suspend", "prepare"])
+    }
+
+    func testBackgroundRefreshExpirationSuppressesDeferredNormalCloseAndCompletion() async {
+        let state = MLSBackgroundRefreshTerminationState()
+        let preparationStarted = expectation(description: "background preparation started")
+        var preparationContinuation: CheckedContinuation<Void, Never>?
+        var events: [String] = []
+
+        let closeTask = Task { @MainActor in
+            await MLSBackgroundRefreshCloseCoordinator.run(
+                state: state,
+                suspendManager: {
+                    events.append("suspend")
+                    return true
+                },
+                prepareRustRuntime: {
+                    events.append("prepare")
+                    preparationStarted.fulfill()
+                    await withCheckedContinuation { continuation in
+                        preparationContinuation = continuation
+                    }
+                    return true
+                },
+                closePreparedRuntime: {
+                    events.append("normal-close")
+                }
+            )
+        }
+
+        await fulfillment(of: [preparationStarted])
+        XCTAssertTrue(state.claimExpiration())
+        events.append("forced-close")
+        XCTAssertTrue(state.claimGRDBEnd())
+        XCTAssertTrue(state.claimTaskCompletion())
+        XCTAssertFalse(state.claimExpiration())
+        XCTAssertFalse(state.claimGRDBEnd())
+        XCTAssertFalse(state.claimTaskCompletion())
+        preparationContinuation?.resume()
+
+        let outcome = await closeTask.value
+        XCTAssertEqual(outcome, .expired)
+        XCTAssertEqual(events, ["suspend", "prepare", "forced-close"])
+    }
+
+    func testBackgroundRefreshCompletionSuppressesLateExpiration() {
+        let state = MLSBackgroundRefreshTerminationState()
+
+        XCTAssertTrue(state.claimTaskCompletion())
+        XCTAssertFalse(state.claimExpiration())
+        XCTAssertFalse(state.claimTaskCompletion())
+    }
+
+    func testForegroundAndBackgroundSourcesHaveNoRawGateClearBypass() throws {
+        let foregroundSource = try source(relativePath: "Catbird/App/CatbirdApp.swift")
+        let foregroundBody = try XCTUnwrap(
+            functionBody(
+                signature: "func resumeMLSAfterReturningToForeground(transitionToken: UInt64) async",
+                in: foregroundSource
+            )
+        )
+        XCTAssertFalse(foregroundBody.contains("clearSuspensionFlag"))
+        XCTAssertFalse(foregroundBody.contains("resumeFromSuspension"))
+        XCTAssertTrue(foregroundBody.contains("resumeMLSOperations"))
+        XCTAssertTrue(foregroundBody.contains("reloadMLSProjectionFromDisk"))
+        XCTAssertTrue(
+            foregroundSource.contains(
+                "if (oldPhase == .background || oldPhase == .inactive), newPhase == .active"
+            )
+        )
+        let staleResumeBody = try XCTUnwrap(
+            functionBody(signature: "reassertSuspensionAfterStaleResume:", in: foregroundBody)
+        )
+        XCTAssertTrue(staleResumeBody.contains("MLSClient.interruptAllContexts()"))
+        XCTAssertTrue(staleResumeBody.contains("MLSCoreContext.interruptAllContexts()"))
+        XCTAssertFalse(staleResumeBody.contains("suspendMLSOperations"))
+        XCTAssertFalse(staleResumeBody.contains("emergencyCloseAllContexts"))
+        XCTAssertFalse(staleResumeBody.contains("markRustRuntimeClosedForSuspend"))
+
+        let backgroundSource = try source(
+            relativePath: "Catbird/Services/MLS/MLSBackgroundRefreshManager.swift"
+        )
+        let backgroundBody = try XCTUnwrap(
+            functionBody(signature: "private func handleBackgroundRefresh(task: BGProcessingTask) async", in: backgroundSource)
+        )
+        XCTAssertFalse(backgroundBody.contains("clearSuspensionFlag"))
+        XCTAssertFalse(backgroundBody.contains("resumeMLSOperations"))
+        XCTAssertTrue(backgroundBody.contains("shouldDeferForLifecycleSuspension"))
+        XCTAssertTrue(backgroundBody.contains("setTaskCompleted(success: false)"))
+        XCTAssertTrue(backgroundBody.contains("manager.suspendMLSOperations()"))
+        XCTAssertTrue(backgroundBody.contains("manager.prepareRustRuntimeForSuspensionAfterDrain(timeout: 5)"))
+
+        let backgroundCloseBody = try XCTUnwrap(
+            functionBody(signature: "closePreparedRuntime:", in: backgroundBody)
+        )
+        let clientClose = try XCTUnwrap(
+            backgroundCloseBody.range(of: "MLSClient.emergencyCloseAllContexts(")
+        )
+        let coreClose = try XCTUnwrap(
+            backgroundCloseBody.range(of: "MLSCoreContext.emergencyCloseAllContexts()")
+        )
+        let runtimeMark = try XCTUnwrap(
+            backgroundCloseBody.range(of: "manager.markRustRuntimeClosedForSuspend(")
+        )
+        XCTAssertLessThan(clientClose.lowerBound, coreClose.lowerBound)
+        XCTAssertLessThan(coreClose.lowerBound, runtimeMark.lowerBound)
+        XCTAssertFalse(backgroundCloseBody.contains("await"))
+
+        let expirationBody = try XCTUnwrap(
+            functionBody(signature: "let expire: @Sendable () -> Void", in: backgroundBody)
+        )
+        XCTAssertTrue(expirationBody.contains("terminationState.claimExpiration()"))
+        XCTAssertTrue(expirationBody.contains("MLSClient.emergencyCloseAllContexts("))
+        XCTAssertTrue(expirationBody.contains("markBackgroundRefreshRustRuntimeClosedSynchronously("))
+        XCTAssertTrue(expirationBody.contains("terminationState.claimTaskCompletion()"))
+    }
+
+    func testAppStateSeparatesAuthoritativeReloadFromProjectionReload() throws {
+        let appStateSource = try source(relativePath: "Catbird/Core/State/AppState.swift")
+        let authoritativeBody = try XCTUnwrap(
+            functionBody(signature: "func reloadMLSStateFromDisk() async", in: appStateSource)
+        )
+        let projectionBody = try XCTUnwrap(
+            functionBody(signature: "func reloadMLSProjectionFromDisk() async", in: appStateSource)
+        )
+
+        XCTAssertTrue(authoritativeBody.contains("manager.reloadStateFromDisk"))
+        XCTAssertTrue(authoritativeBody.contains("reloadMLSProjectionFromDisk"))
+        XCTAssertFalse(projectionBody.contains("manager.reloadStateFromDisk"))
+        XCTAssertTrue(projectionBody.contains("loadMLSConversations"))
+    }
+
+    func testSuspensionClosePreparesBeforeClosingRuntime() async {
+        var events: [String] = []
+
+        let outcome = await MLSSuspensionCloseCoordinator.run(
+            rustPathAvailable: true,
+            transitionStillCurrent: { true },
+            prepareRustRuntime: {
+                events.append("prepare")
+                return true
+            },
+            closePreparedRuntime: {
+                events.append("close")
+            }
+        )
+
+        XCTAssertEqual(outcome, .closed)
+        XCTAssertEqual(events, ["prepare", "close"])
+    }
+
+    func testSuspensionPreparationFailureSkipsNormalClose() async {
+        var events: [String] = []
+
+        let outcome = await MLSSuspensionCloseCoordinator.run(
+            rustPathAvailable: true,
+            transitionStillCurrent: { true },
+            prepareRustRuntime: {
+                events.append("prepare")
+                return false
+            },
+            closePreparedRuntime: {
+                events.append("close")
+            }
+        )
+
+        XCTAssertEqual(outcome, .preparationFailed)
+        XCTAssertEqual(events, ["prepare"])
+    }
+
+    func testUnavailableRustPathSkipsPreparationAndNormalClose() async {
+        var events: [String] = []
+
+        let outcome = await MLSSuspensionCloseCoordinator.run(
+            rustPathAvailable: false,
+            transitionStillCurrent: { true },
+            prepareRustRuntime: {
+                events.append("prepare")
+                return true
+            },
+            closePreparedRuntime: {
+                events.append("close")
+            }
+        )
+
+        XCTAssertEqual(outcome, .rustPathUnavailable)
+        XCTAssertEqual(events, [])
+    }
+
+    func testNewerForegroundDuringPreparationCannotClosePreparedRuntime() async {
+        var transitionCurrent = true
+        var preparationContinuation: CheckedContinuation<Void, Never>?
+        let preparationStarted = expectation(description: "Rust suspension preparation started")
+        var events: [String] = []
+
+        let closeTask = Task { @MainActor in
+            await MLSSuspensionCloseCoordinator.run(
+                rustPathAvailable: true,
+                transitionStillCurrent: { transitionCurrent },
+                prepareRustRuntime: {
+                    events.append("prepare")
+                    preparationStarted.fulfill()
+                    await withCheckedContinuation { continuation in
+                        preparationContinuation = continuation
+                    }
+                    return true
+                },
+                closePreparedRuntime: {
+                    events.append("close")
+                }
+            )
+        }
+
+        await fulfillment(of: [preparationStarted])
+        transitionCurrent = false
+        preparationContinuation?.resume()
+
+        let outcome = await closeTask.value
+        XCTAssertEqual(outcome, .staleTransition)
+        XCTAssertEqual(events, ["prepare"])
+    }
+
+    func testSceneSuspensionCapturesRustAvailabilityBeforeGRDBAndClosesOnlyAfterPrepare() throws {
+        let appSource = try source(relativePath: "Catbird/App/CatbirdApp.swift")
+        let body = try XCTUnwrap(
+            functionBody(
+                signature: "func handleScenePhaseChange(from oldPhase: ScenePhase, to newPhase: ScenePhase)",
+                in: appSource
+            )
+        )
+
+        let suspendRange = try XCTUnwrap(
+            body.range(of: "rustPathAvailable = manager.suspendMLSOperations()")
+        )
+        let grdbRange = try XCTUnwrap(
+            body.range(of: "GRDBSuspensionCoordinator.setLifecycleSuspended(")
+        )
+        XCTAssertLessThan(suspendRange.lowerBound, grdbRange.lowerBound)
+        XCTAssertTrue(body.contains("manager.prepareRustRuntimeForSuspensionAfterDrain(timeout: 5)"))
+
+        let closeBody = try XCTUnwrap(
+            functionBody(signature: "closePreparedRuntime:", in: body)
+        )
+        let clientClose = try XCTUnwrap(closeBody.range(of: "MLSClient.emergencyCloseAllContexts("))
+        let coreClose = try XCTUnwrap(closeBody.range(of: "MLSCoreContext.emergencyCloseAllContexts()"))
+        let runtimeMark = try XCTUnwrap(closeBody.range(of: "manager.markRustRuntimeClosedForSuspend("))
+        XCTAssertLessThan(clientClose.lowerBound, coreClose.lowerBound)
+        XCTAssertLessThan(coreClose.lowerBound, runtimeMark.lowerBound)
+        XCTAssertFalse(closeBody.contains("await"))
+        XCTAssertTrue(
+            body.contains(
+                "if newPhase == .inactive || newPhase == .background {\n" +
+                    "        // WAL health snapshot BEFORE suspension"
+            )
+        )
+        XCTAssertFalse(
+            body.contains(
+                "if oldPhase == .active, newPhase == .inactive || newPhase == .background"
+            )
+        )
+    }
+
+    func testScenePhaseHandlerDeclaresMainActorIsolation() throws {
+        let appSource = try source(relativePath: "Catbird/App/CatbirdApp.swift")
+
+        XCTAssertTrue(
+            appSource.contains(
+                "  @MainActor\n" +
+                    "  func handleScenePhaseChange(from oldPhase: ScenePhase, to newPhase: ScenePhase)"
+            )
+        )
+    }
+
+    func testSuspensionExpirationPathsUseSharedOneShotCloseClaim() throws {
+        let appSource = try source(relativePath: "Catbird/App/CatbirdApp.swift")
+        let body = try XCTUnwrap(
+            functionBody(
+                signature: "func handleScenePhaseChange(from oldPhase: ScenePhase, to newPhase: ScenePhase)",
+                in: appSource
+            )
+        )
+        let sceneExpiration = try XCTUnwrap(
+            functionBody(signature: "beginBackgroundTask(withName: \"ScenePhaseTransition\")", in: body)
+        )
+        let closeExpiration = try XCTUnwrap(
+            functionBody(signature: "CatbirdBackgroundTask(name: \"MLSSuspensionClose\")", in: body)
+        )
+
+        for expirationBody in [sceneExpiration, closeExpiration] {
+            XCTAssertTrue(expirationBody.contains("forceCloseSceneSuspensionSynchronously("))
+            XCTAssertFalse(expirationBody.contains("MLSClient.emergencyCloseAllContexts("))
+            XCTAssertFalse(expirationBody.contains("MLSCoreContext.emergencyCloseAllContexts()"))
+            XCTAssertFalse(expirationBody.contains("markRustRuntimeClosedForSuspend("))
+        }
+    }
+
+    func testSceneExpirationHandlersRaceForExactlyOneCloseAndMark() {
+        let transitionToken = MLSForegroundResumeCoordinator.recordSceneTransition(to: .background)
+        let closeClaim = MLSSceneSuspensionCloseClaim(
+            transitionToken: transitionToken,
+            expectedPhase: .background
+        )
+        var closeCount = 0
+        var markCount = 0
+
+        for _ in 0..<2 where closeClaim.claimExpirationIfCurrent() {
+            closeCount += 1
+            markCount += 1
+        }
+
+        XCTAssertEqual(closeCount, 1)
+        XCTAssertEqual(markCount, 1)
+    }
+
+    func testStaleSceneExpirationCannotCloseNewerForegroundRuntime() {
+        let transitionToken = MLSForegroundResumeCoordinator.recordSceneTransition(to: .background)
+        let closeClaim = MLSSceneSuspensionCloseClaim(
+            transitionToken: transitionToken,
+            expectedPhase: .background
+        )
+        _ = MLSForegroundResumeCoordinator.recordSceneTransition(to: .active)
+
+        XCTAssertFalse(closeClaim.claimExpirationIfCurrent())
+    }
+
+    func testNormalSceneCloseSuppressesLateExpirationCloseAndMark() {
+        let transitionToken = MLSForegroundResumeCoordinator.recordSceneTransition(to: .inactive)
+        let closeClaim = MLSSceneSuspensionCloseClaim(
+            transitionToken: transitionToken,
+            expectedPhase: .inactive
+        )
+        var closeCount = 0
+        var markCount = 0
+
+        if closeClaim.claimNormalCloseIfCurrent() {
+            closeCount += 1
+            markCount += 1
+        }
+        if closeClaim.claimExpirationIfCurrent() {
+            closeCount += 1
+            markCount += 1
+        }
+
+        XCTAssertEqual(closeCount, 1)
+        XCTAssertEqual(markCount, 1)
+    }
+
+    func testBackgroundBeforeFirstChatUsesOwnedContextFreeSuspensionLifecycle() throws {
+        let appSource = try source(relativePath: "Catbird/App/CatbirdApp.swift")
+        let sceneHandler = try XCTUnwrap(
+            functionBody(
+                signature: "func handleScenePhaseChange(from oldPhase: ScenePhase, to newPhase: ScenePhase)",
+                in: appSource
+            )
+        )
+        let foregroundResume = try XCTUnwrap(
+            functionBody(
+                signature: "private func resumeMLSAfterReturningToForeground(transitionToken: UInt64) async",
+                in: appSource
+            )
+        )
+
+        XCTAssertTrue(
+            appSource.contains(
+                "private let contextFreeMLSSuspensionOwner = "
+                    + "MLSContextFreeLifecycleSuspensionOwner()"
+            )
+        )
+        XCTAssertTrue(
+            sceneHandler.contains(
+                "contextFreeMLSSuspensionOwner.markSuspensionInProgress("
+            )
+        )
+        XCTAssertTrue(
+            foregroundResume.contains(
+                "await contextFreeMLSSuspensionOwner.resumeSuspensionIfOwnedAndContextFree()"
+            )
+        )
+        XCTAssertTrue(
+            foregroundResume.contains(
+                "MLSForegroundResumeCoordinator.isCurrentActiveTransition(transitionToken)"
+            )
+        )
+        XCTAssertFalse(foregroundResume.contains("MLSClient.clearSuspension"))
+        XCTAssertFalse(foregroundResume.contains("MLSCoreContext.clearSuspensionFlag"))
+    }
+
+    private func source(relativePath: String) throws -> String {
+        let repositoryRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        return try String(
+            contentsOf: repositoryRoot.appendingPathComponent(relativePath),
+            encoding: .utf8
+        )
+    }
+
+    private func functionBody(signature: String, in source: String) -> String? {
+        guard let signatureRange = source.range(of: signature),
+              let openingBrace = source[signatureRange.upperBound...].firstIndex(of: "{")
+        else {
+            return nil
+        }
+
+        var depth = 0
+        var cursor = openingBrace
+        while cursor < source.endIndex {
+            switch source[cursor] {
+            case "{":
+                depth += 1
+            case "}":
+                depth -= 1
+                if depth == 0 {
+                    return String(source[openingBrace ... cursor])
+                }
+            default:
+                break
+            }
+            cursor = source.index(after: cursor)
+        }
+        return nil
+    }
+}
+
+@MainActor
+final class MLSForegroundResumeRaceTests: XCTestCase {
+    func testBackgroundSupersedesInactivePreparationAndOwnsSingleClose() async {
+        let inactiveToken = MLSForegroundResumeCoordinator.recordSceneTransition(to: .inactive)
+        let preparationStarted = expectation(description: "inactive preparation started")
+        var preparationContinuation: CheckedContinuation<Void, Never>?
+        var closes: [String] = []
+
+        let inactiveClose = Task { @MainActor in
+            await MLSSuspensionCloseCoordinator.run(
+                rustPathAvailable: true,
+                transitionStillCurrent: {
+                    MLSForegroundResumeCoordinator.isCurrentTransition(
+                        inactiveToken,
+                        expectedPhase: .inactive
+                    )
+                },
+                prepareRustRuntime: {
+                    preparationStarted.fulfill()
+                    await withCheckedContinuation { continuation in
+                        preparationContinuation = continuation
+                    }
+                    return true
+                },
+                closePreparedRuntime: {
+                    closes.append("inactive")
+                }
+            )
+        }
+
+        await fulfillment(of: [preparationStarted])
+        let backgroundToken = MLSForegroundResumeCoordinator.recordSceneTransition(to: .background)
+        let backgroundOutcome = await MLSSuspensionCloseCoordinator.run(
+            rustPathAvailable: true,
+            transitionStillCurrent: {
+                MLSForegroundResumeCoordinator.isCurrentTransition(
+                    backgroundToken,
+                    expectedPhase: .background
+                )
+            },
+            prepareRustRuntime: { true },
+            closePreparedRuntime: {
+                closes.append("background")
+            }
+        )
+        preparationContinuation?.resume()
+        let inactiveOutcome = await inactiveClose.value
+
+        XCTAssertEqual(backgroundOutcome, .closed)
+        XCTAssertEqual(inactiveOutcome, .staleTransition)
+        XCTAssertEqual(closes, ["background"])
+    }
+
+    func testClosedInactiveRuntimeCanBeReusedByBackgroundButNotForeground() {
+        let inactiveToken = MLSForegroundResumeCoordinator.recordSceneTransition(to: .inactive)
+        XCTAssertTrue(
+            MLSForegroundResumeCoordinator.markRustRuntimeClosedForSuspension(
+                inactiveToken,
+                expectedPhase: .inactive
+            )
+        )
+
+        let backgroundToken = MLSForegroundResumeCoordinator.recordSceneTransition(to: .background)
+        XCTAssertTrue(
+            MLSForegroundResumeCoordinator.hasClosedRustRuntimeForSuspension(
+                backgroundToken,
+                expectedPhase: .background
+            )
+        )
+
+        let foregroundToken = MLSForegroundResumeCoordinator.recordSceneTransition(to: .active)
+        XCTAssertFalse(
+            MLSForegroundResumeCoordinator.hasClosedRustRuntimeForSuspension(
+                foregroundToken,
+                expectedPhase: .active
+            )
+        )
+    }
+
+    func testStaleSceneTaskStopsAfterFeedStateAwaitBeforeLifecycleEffects() async {
+        let transitionToken = MLSForegroundResumeCoordinator.recordSceneTransition(to: .active)
+        var feedContinuation: CheckedContinuation<Void, Never>?
+        let feedUpdateStarted = expectation(description: "feed-state update started")
+        var events: [String] = []
+
+        let sceneTask = Task { @MainActor in
+            feedUpdateStarted.fulfill()
+            await withCheckedContinuation { continuation in
+                feedContinuation = continuation
+            }
+            guard MLSForegroundResumeCoordinator.isCurrentTransition(
+                transitionToken,
+                expectedPhase: .active
+            ) else {
+                return
+            }
+            events.append("publish-active")
+        }
+
+        await fulfillment(of: [feedUpdateStarted])
+        _ = MLSForegroundResumeCoordinator.recordSceneTransition(to: .background)
+        feedContinuation?.resume()
+        await sceneTask.value
+
+        XCTAssertEqual(events, [])
+    }
+
+    func testStaleSuspensionTaskStopsAfterDelayBeforePublishingInactive() async {
+        let transitionToken = MLSForegroundResumeCoordinator.recordSceneTransition(to: .background)
+        var delayContinuation: CheckedContinuation<Void, Never>?
+        let delayStarted = expectation(description: "post-close delay started")
+        var events: [String] = []
+
+        let sceneTask = Task { @MainActor in
+            guard MLSForegroundResumeCoordinator.isCurrentTransition(
+                transitionToken,
+                expectedPhase: .background
+            ) else {
+                return
+            }
+            events.append("close-runtime")
+            delayStarted.fulfill()
+            await withCheckedContinuation { continuation in
+                delayContinuation = continuation
+            }
+            guard MLSForegroundResumeCoordinator.isCurrentTransition(
+                transitionToken,
+                expectedPhase: .background
+            ) else {
+                return
+            }
+            events.append("publish-inactive")
+        }
+
+        await fulfillment(of: [delayStarted])
+        _ = MLSForegroundResumeCoordinator.recordSceneTransition(to: .active)
+        delayContinuation?.resume()
+        await sceneTask.value
+
+        XCTAssertEqual(events, ["close-runtime"])
+    }
+
+    func testNewerSuspensionRevokesPausedForegroundResumeBeforeManagerGateRelease() async {
+        let foregroundToken = MLSForegroundResumeCoordinator.recordSceneTransition(to: .active)
+        var preparationContinuation: CheckedContinuation<Void, Never>?
+        let preparationStarted = expectation(description: "foreground preparation started")
+        var events: [String] = []
+        var gatesClosed = true
+
+        let resumeTask = Task { @MainActor in
+            await MLSForegroundResumeCoordinator.run(
+                managerAvailable: true,
+                resumeStillCurrent: {
+                    MLSForegroundResumeCoordinator.isCurrentActiveTransition(foregroundToken)
+                },
+                prepareStorage: {
+                    events.append("prepare")
+                    preparationStarted.fulfill()
+                    await withCheckedContinuation { continuation in
+                        preparationContinuation = continuation
+                    }
+                },
+                resumeManager: {
+                    events.append("resume")
+                    gatesClosed = false
+                    return .resumed
+                },
+                reassertSuspensionAfterStaleResume: {
+                    events.append("reassert")
+                    gatesClosed = true
+                },
+                reloadProjection: {
+                    events.append("projection")
+                },
+                performBackup: {
+                    events.append("backup")
+                }
+            )
+        }
+
+        await fulfillment(of: [preparationStarted])
+        _ = MLSForegroundResumeCoordinator.recordSceneTransition(to: .background)
+        preparationContinuation?.resume()
+
+        let result = await resumeTask.value
+        XCTAssertEqual(result, .staleTransition)
+        XCTAssertEqual(events, ["prepare"])
+        XCTAssertTrue(gatesClosed)
+    }
+
+    func testNewerSuspensionDuringManagerResumeIsReassertedBeforeProjectionAndBackup() async {
+        let foregroundToken = MLSForegroundResumeCoordinator.recordSceneTransition(to: .active)
+        var managerContinuation: CheckedContinuation<Void, Never>?
+        let managerResumeStarted = expectation(description: "manager resume started")
+        var events: [String] = []
+        var gatesClosed = true
+
+        let resumeTask = Task { @MainActor in
+            await MLSForegroundResumeCoordinator.run(
+                managerAvailable: true,
+                resumeStillCurrent: {
+                    MLSForegroundResumeCoordinator.isCurrentActiveTransition(foregroundToken)
+                },
+                prepareStorage: {
+                    events.append("prepare")
+                },
+                resumeManager: {
+                    events.append("resume")
+                    managerResumeStarted.fulfill()
+                    await withCheckedContinuation { continuation in
+                        managerContinuation = continuation
+                    }
+                    gatesClosed = false
+                    return .resumed
+                },
+                reassertSuspensionAfterStaleResume: {
+                    events.append("reassert")
+                    gatesClosed = true
+                },
+                reloadProjection: {
+                    events.append("projection")
+                },
+                performBackup: {
+                    events.append("backup")
+                }
+            )
+        }
+
+        await fulfillment(of: [managerResumeStarted])
+        _ = MLSForegroundResumeCoordinator.recordSceneTransition(to: .background)
+        managerContinuation?.resume()
+
+        let result = await resumeTask.value
+        XCTAssertEqual(result, .staleTransition)
+        XCTAssertEqual(events, ["prepare", "resume", "reassert"])
+        XCTAssertTrue(gatesClosed)
+    }
+
+    func testProductionOrderedSupersessionCannotReopenNewerSuspensionGates() async throws {
+        let repositoryRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let appSource = try String(
+            contentsOf: repositoryRoot.appendingPathComponent("Catbird/App/CatbirdApp.swift"),
+            encoding: .utf8
+        )
+        func extractFunctionBody(signature: String, from source: String) -> String? {
+            guard let signatureRange = source.range(of: signature),
+                  let openingBrace = source[signatureRange.upperBound...].firstIndex(of: "{")
+            else {
+                return nil
+            }
+
+            var depth = 0
+            var cursor = openingBrace
+            while cursor < source.endIndex {
+                switch source[cursor] {
+                case "{":
+                    depth += 1
+                case "}":
+                    depth -= 1
+                    if depth == 0 {
+                        return String(source[openingBrace ... cursor])
+                    }
+                default:
+                    break
+                }
+                cursor = source.index(after: cursor)
+            }
+            return nil
+        }
+        let sceneHandler = try XCTUnwrap(
+            extractFunctionBody(
+                signature: "func handleScenePhaseChange(from oldPhase: ScenePhase, to newPhase: ScenePhase)",
+                from: appSource
+            )
+        )
+        let recordTransition = try XCTUnwrap(
+            sceneHandler.range(of: "MLSForegroundResumeCoordinator.recordSceneTransition(to: newPhase)")
+        )
+        let ownerBoundSuspend = try XCTUnwrap(
+            sceneHandler.range(of: "rustPathAvailable = manager.suspendMLSOperations()")
+        )
+        let coreGateClose = try XCTUnwrap(
+            sceneHandler.range(of: "MLSCoreContext.markSuspensionInProgress()")
+        )
+        let firstAwaitingTask = try XCTUnwrap(sceneHandler.range(of: "Task { @MainActor in"))
+        XCTAssertLessThan(recordTransition.lowerBound, ownerBoundSuspend.lowerBound)
+        XCTAssertLessThan(ownerBoundSuspend.lowerBound, coreGateClose.lowerBound)
+        XCTAssertLessThan(coreGateClose.lowerBound, firstAwaitingTask.lowerBound)
+
+        let foregroundToken = MLSForegroundResumeCoordinator.recordSceneTransition(to: .active)
+        var managerContinuation: CheckedContinuation<Void, Never>?
+        let managerResumeStarted = expectation(description: "generation-bound manager resume started")
+        let capturedResumeGeneration = 1
+        var suspensionGeneration = capturedResumeGeneration
+        var suspensionOwner = "foreground-manager"
+        var clientGateClosed = true
+        var coreGateClosed = true
+        var staleReassertCount = 0
+        var staleCloseCount = 0
+        var staleReleaseCount = 0
+
+        let resumeTask = Task { @MainActor in
+            await MLSForegroundResumeCoordinator.run(
+                managerAvailable: true,
+                resumeStillCurrent: {
+                    MLSForegroundResumeCoordinator.isCurrentActiveTransition(foregroundToken)
+                },
+                prepareStorage: {},
+                resumeManager: {
+                    managerResumeStarted.fulfill()
+                    await withCheckedContinuation { continuation in
+                        managerContinuation = continuation
+                    }
+
+                    // This models Core's exact-generation final release: a newer
+                    // suspension revokes the captured resume authority before either
+                    // admission gate can be cleared.
+                    guard suspensionGeneration == capturedResumeGeneration else {
+                        return .failedStillSuspended
+                    }
+                    clientGateClosed = false
+                    coreGateClosed = false
+                    staleReleaseCount += 1
+                    return .resumed
+                },
+                reassertSuspensionAfterStaleResume: {
+                    staleReassertCount += 1
+                },
+                reloadProjection: {
+                    staleCloseCount += 1
+                },
+                performBackup: {
+                    staleReleaseCount += 1
+                }
+            )
+        }
+
+        await fulfillment(of: [managerResumeStarted])
+
+        // Production performs all four operations synchronously on MainActor
+        // before yielding to the lifecycle Task.
+        let newerBackgroundToken = MLSForegroundResumeCoordinator.recordSceneTransition(to: .background)
+        suspensionGeneration += 1
+        suspensionOwner = "newer-background-transition"
+        clientGateClosed = true
+        coreGateClosed = true
+        managerContinuation?.resume()
+
+        let outcome = await resumeTask.value
+        let freshFFIAdmissionAllowed = !clientGateClosed && !coreGateClosed
+
+        XCTAssertEqual(outcome, .failedStillSuspended)
+        XCTAssertTrue(clientGateClosed)
+        XCTAssertTrue(coreGateClosed)
+        XCTAssertFalse(freshFFIAdmissionAllowed)
+        XCTAssertEqual(suspensionGeneration, 2)
+        XCTAssertEqual(suspensionOwner, "newer-background-transition")
+        XCTAssertTrue(
+            MLSForegroundResumeCoordinator.isCurrentTransition(
+                newerBackgroundToken,
+                expectedPhase: .background
+            )
+        )
+        XCTAssertEqual(staleReassertCount, 0)
+        XCTAssertEqual(staleCloseCount, 0)
+        XCTAssertEqual(staleReleaseCount, 0)
+    }
+}

--- a/CatbirdTests/MLSForegroundResumeContractTests.swift
+++ b/CatbirdTests/MLSForegroundResumeContractTests.swift
@@ -470,6 +470,96 @@ final class MLSForegroundResumeContractTests: XCTestCase {
         }
     }
 
+    func testContextFreeExpirationPreservesExactOwnerForForegroundResume() async {
+        let owner = MLSContextFreeLifecycleSuspensionOwner()
+        owner.markSuspensionInProgress(reason: "manager-free background")
+
+        XCTAssertTrue(
+            owner.emergencyCloseAllContextsIfOwned(reason: "manager-free expiration")
+        )
+        XCTAssertTrue(MLSClient.isSuspensionInProgress)
+        XCTAssertTrue(MLSCoreContext.isSuspensionInProgress)
+
+        let resumed = await owner.resumeSuspensionIfOwnedAndContextFree()
+        XCTAssertTrue(resumed)
+        XCTAssertFalse(MLSClient.isSuspensionInProgress)
+        XCTAssertFalse(MLSCoreContext.isSuspensionInProgress)
+    }
+
+    func testRotatedContextFreeOwnerCannotCloseOrReleaseSuccessor() async {
+        let staleOwner = MLSContextFreeLifecycleSuspensionOwner()
+        staleOwner.markSuspensionInProgress(reason: "older background")
+
+        let currentOwner = MLSContextFreeLifecycleSuspensionOwner()
+        currentOwner.markSuspensionInProgress(reason: "newer background")
+
+        XCTAssertFalse(
+            staleOwner.emergencyCloseAllContextsIfOwned(reason: "stale expiration")
+        )
+        let staleReleased = await staleOwner.resumeSuspensionIfOwnedAndContextFree()
+        XCTAssertFalse(staleReleased)
+        XCTAssertTrue(MLSClient.isSuspensionInProgress)
+        XCTAssertTrue(MLSCoreContext.isSuspensionInProgress)
+
+        XCTAssertTrue(
+            currentOwner.emergencyCloseAllContextsIfOwned(reason: "current expiration")
+        )
+        let currentReleased = await currentOwner.resumeSuspensionIfOwnedAndContextFree()
+        XCTAssertTrue(currentReleased)
+        XCTAssertFalse(MLSClient.isSuspensionInProgress)
+        XCTAssertFalse(MLSCoreContext.isSuspensionInProgress)
+    }
+
+    func testSceneTransitionCapturesContextFreeOwnerBeforeExpirationClosures() throws {
+        let appSource = try source(relativePath: "Catbird/App/CatbirdApp.swift")
+        let sceneHandler = try XCTUnwrap(
+            functionBody(
+                signature: "func handleScenePhaseChange(from oldPhase: ScenePhase, to newPhase: ScenePhase)",
+                in: appSource
+            )
+        )
+        let ownerCapture = try XCTUnwrap(
+            sceneHandler.range(
+                of: "contextFreeSuspensionOwner = "
+                    + "appStateManager.contextFreeMLSSuspensionOwner"
+            )
+        )
+        let firstExpiration = try XCTUnwrap(
+            sceneHandler.range(of: "beginBackgroundTask(withName: \"ScenePhaseTransition\")")
+        )
+        let asynchronousLifecycleTask = try XCTUnwrap(
+            sceneHandler.range(of: "Task { @MainActor in")
+        )
+
+        XCTAssertLessThan(ownerCapture.lowerBound, firstExpiration.lowerBound)
+        XCTAssertLessThan(ownerCapture.lowerBound, asynchronousLifecycleTask.lowerBound)
+
+        let forceClose = try XCTUnwrap(
+            functionBody(signature: "func forceCloseSceneSuspensionSynchronously(", in: appSource)
+        )
+        let managerClose = try XCTUnwrap(
+            functionBody(signature: "if let manager", in: forceClose)
+        )
+        let contextFreeStart = try XCTUnwrap(
+            forceClose.range(of: "} else {\n      guard")
+        )
+        let sceneCloseMark = try XCTUnwrap(
+            forceClose.range(
+                of: "MLSForegroundResumeCoordinator.markRustRuntimeClosedForSuspension("
+            )
+        )
+        let contextFreeClose = String(
+            forceClose[contextFreeStart.upperBound ..< sceneCloseMark.lowerBound]
+        )
+        XCTAssertTrue(managerClose.contains("MLSClient.interruptAllContexts()"))
+        XCTAssertTrue(managerClose.contains("MLSCoreContext.interruptAllContexts()"))
+        XCTAssertTrue(managerClose.contains("MLSClient.emergencyCloseAllContexts("))
+        XCTAssertTrue(contextFreeClose.contains("contextFreeSuspensionOwner"))
+        XCTAssertTrue(contextFreeClose.contains(".emergencyCloseAllContextsIfOwned("))
+        XCTAssertFalse(contextFreeClose.contains("interruptAllContexts"))
+        XCTAssertFalse(contextFreeClose.contains("MLSClient.emergencyCloseAllContexts("))
+    }
+
     func testSceneExpirationHandlersRaceForExactlyOneCloseAndMark() {
         let transitionToken = MLSForegroundResumeCoordinator.recordSceneTransition(to: .background)
         let closeClaim = MLSSceneSuspensionCloseClaim(

--- a/CatbirdTests/NSENotificationProcessingLeaseContractTests.swift
+++ b/CatbirdTests/NSENotificationProcessingLeaseContractTests.swift
@@ -1,0 +1,302 @@
+@testable import Catbird
+import XCTest
+
+@MainActor
+final class NSEProcessingLeaseContractTests: XCTestCase {
+  func testOverlappingReleasesGiveCleanupOnlyToFinalLease() async {
+    let leases = NSENotificationProcessingLeases()
+    let first = await leases.acquire(recipientDID: "did:plc:first")
+    let second = await leases.acquire(recipientDID: "did:plc:second")
+
+    XCTAssertEqual(leases.release(first), .stillProcessing)
+    guard case .performCleanup(let claim) = leases.release(second) else {
+      return XCTFail("Final lease did not receive cleanup ownership")
+    }
+    XCTAssertTrue(leases.ordinaryCleanupIsCurrent(claim))
+
+    leases.finishOrdinaryCleanup(claim)
+    XCTAssertEqual(leases.release(second), .cleanupAlreadyPerformed)
+  }
+
+  func testExpirationSupersedesHeldOrdinaryCleanupExactlyOnce() async {
+    let leases = NSENotificationProcessingLeases()
+    let lease = await leases.acquire(recipientDID: "did:plc:expiry")
+    guard case .performCleanup(let ordinaryClaim) = leases.release(lease) else {
+      return XCTFail("Final lease did not receive cleanup ownership")
+    }
+
+    XCTAssertTrue(leases.claimExpirationCleanup())
+    XCTAssertFalse(leases.claimExpirationCleanup())
+    XCTAssertFalse(leases.ordinaryCleanupIsCurrent(ordinaryClaim))
+    leases.finishExpirationCleanupIfIdle()
+    leases.finishOrdinaryCleanup(ordinaryClaim)
+
+    XCTAssertFalse(leases.claimExpirationCleanup())
+  }
+
+  func testExpirationAfterCompletedOrdinaryCleanupDoesNotCloseAgain() async {
+    let leases = NSENotificationProcessingLeases()
+    let lease = await leases.acquire(recipientDID: "did:plc:complete")
+    guard case .performCleanup(let ordinaryClaim) = leases.release(lease) else {
+      return XCTFail("Final lease did not receive cleanup ownership")
+    }
+
+    leases.finishOrdinaryCleanup(ordinaryClaim)
+
+    XCTAssertFalse(leases.claimExpirationCleanup())
+  }
+
+  func testExpirationDefersToOrdinaryCleanupAfterAtomicCloseClaim() async {
+    let leases = NSENotificationProcessingLeases()
+    let lease = await leases.acquire(recipientDID: "did:plc:closing")
+    guard case .performCleanup(let ordinaryClaim) = leases.release(lease) else {
+      return XCTFail("Final lease did not receive cleanup ownership")
+    }
+
+    XCTAssertTrue(leases.beginOrdinaryClose(ordinaryClaim))
+    XCTAssertFalse(leases.claimExpirationCleanup())
+    XCTAssertTrue(leases.ordinaryCleanupIsCurrent(ordinaryClaim))
+    leases.finishOrdinaryCleanup(ordinaryClaim)
+    XCTAssertFalse(leases.claimExpirationCleanup())
+  }
+
+  func testAcquisitionWaitsForCleanupThenStartsNextGeneration() async {
+    let leases = NSENotificationProcessingLeases()
+    let first = await leases.acquire(recipientDID: "did:plc:first")
+    guard case .performCleanup(let ordinaryClaim) = leases.release(first) else {
+      return XCTFail("Final lease did not receive cleanup ownership")
+    }
+
+    var acquisitionFinished = false
+    let waitingAcquisition = Task { @MainActor in
+      let lease = await leases.acquire(recipientDID: "did:plc:next")
+      acquisitionFinished = true
+      return lease
+    }
+    await Task.yield()
+    XCTAssertFalse(acquisitionFinished)
+
+    leases.finishOrdinaryCleanup(ordinaryClaim)
+    let next = await waitingAcquisition.value
+
+    XCTAssertTrue(acquisitionFinished)
+    XCTAssertTrue(next.startsNewGeneration)
+  }
+
+  func testAppStopWaitsForActiveLeaseAndBlocksNewAcquisition() async {
+    let leases = NSENotificationProcessingLeases()
+    let active = await leases.acquire(recipientDID: "did:plc:active")
+
+    var stopFinishedWaiting = false
+    let stopRequest = Task { @MainActor in
+      let decision = await leases.requestAppStopCleanup()
+      stopFinishedWaiting = true
+      return decision
+    }
+    await Task.yield()
+    XCTAssertFalse(stopFinishedWaiting)
+
+    var acquisitionFinished = false
+    let waitingAcquisition = Task { @MainActor in
+      let lease = await leases.acquire(recipientDID: "did:plc:later")
+      acquisitionFinished = true
+      return lease
+    }
+    await Task.yield()
+    XCTAssertFalse(acquisitionFinished)
+
+    XCTAssertEqual(leases.release(active), .cleanupOwnedElsewhere)
+    guard case .performCleanup(let stopClaim) = await stopRequest.value else {
+      return XCTFail("App stop did not receive cleanup ownership")
+    }
+    XCTAssertTrue(stopFinishedWaiting)
+    XCTAssertEqual(stopClaim.recipientDIDs, ["did:plc:active"])
+    XCTAssertFalse(acquisitionFinished)
+
+    leases.finishAppStopCleanup(stopClaim)
+    let later = await waitingAcquisition.value
+    XCTAssertTrue(acquisitionFinished)
+    XCTAssertTrue(later.startsNewGeneration)
+  }
+
+  func testAppStopPreservesDistinctOverlappingRecipients() async {
+    let leases = NSENotificationProcessingLeases()
+    let first = await leases.acquire(recipientDID: "did:plc:first")
+    let second = await leases.acquire(recipientDID: "did:plc:second")
+    let stopRequest = Task { @MainActor in
+      await leases.requestAppStopCleanup()
+    }
+    await Task.yield()
+
+    XCTAssertEqual(leases.release(first), .stillProcessing)
+    XCTAssertEqual(leases.release(second), .cleanupOwnedElsewhere)
+    guard case .performCleanup(let stopClaim) = await stopRequest.value else {
+      return XCTFail("App stop did not receive cleanup ownership")
+    }
+
+    XCTAssertEqual(stopClaim.recipientDIDs, ["did:plc:first", "did:plc:second"])
+    leases.finishAppStopCleanup(stopClaim)
+  }
+
+  func testExpirationSupersedesAppStopBeforeCloseBegins() async {
+    let leases = NSENotificationProcessingLeases()
+    let active = await leases.acquire(recipientDID: "did:plc:active")
+    let stopRequest = Task { @MainActor in
+      await leases.requestAppStopCleanup()
+    }
+    await Task.yield()
+    XCTAssertEqual(leases.release(active), .cleanupOwnedElsewhere)
+    guard case .performCleanup(let stopClaim) = await stopRequest.value else {
+      return XCTFail("App stop did not receive cleanup ownership")
+    }
+
+    XCTAssertTrue(leases.claimExpirationCleanup())
+    XCTAssertFalse(leases.appStopCleanupIsCurrent(stopClaim))
+    leases.finishExpirationCleanupIfIdle()
+    leases.finishAppStopCleanup(stopClaim)
+    XCTAssertFalse(leases.claimExpirationCleanup())
+  }
+
+  func testExpirationDefersToAppStopAfterAtomicCloseClaim() async {
+    let leases = NSENotificationProcessingLeases()
+    let active = await leases.acquire(recipientDID: "did:plc:active")
+    let stopRequest = Task { @MainActor in
+      await leases.requestAppStopCleanup()
+    }
+    await Task.yield()
+    XCTAssertEqual(leases.release(active), .cleanupOwnedElsewhere)
+    guard case .performCleanup(let stopClaim) = await stopRequest.value else {
+      return XCTFail("App stop did not receive cleanup ownership")
+    }
+
+    XCTAssertTrue(leases.beginAppStopClose(stopClaim))
+    XCTAssertFalse(leases.claimExpirationCleanup())
+    XCTAssertTrue(leases.appStopCleanupIsCurrent(stopClaim))
+    leases.finishAppStopCleanup(stopClaim)
+    XCTAssertFalse(leases.claimExpirationCleanup())
+  }
+
+  func testOverlappingNotificationTasksReleaseThroughFinalLeaseCleanup() throws {
+    let source = try notificationServiceSource()
+    let receiveBody = try XCTUnwrap(
+      functionBody(signature: "override func didReceive(", in: source)
+    )
+    let leaseWrapper = try XCTUnwrap(
+      functionBody(signature: "private func withNotificationProcessingLease(", in: source)
+    )
+
+    XCTAssertEqual(
+      receiveBody.components(separatedBy: "withNotificationProcessingLease(").count - 1,
+      2,
+      "Both the rustFull cache path and Swift MLS decrypt path must hold a process lease"
+    )
+    XCTAssertTrue(
+      leaseWrapper.contains(
+        "await Self.notificationProcessingLeases.acquire(recipientDID: recipientDid)"
+      )
+    )
+    XCTAssertTrue(leaseWrapper.contains("await operation()"))
+    XCTAssertTrue(leaseWrapper.contains("Self.notificationProcessingLeases.release(lease)"))
+    XCTAssertTrue(leaseWrapper.contains("case .stillProcessing"))
+    XCTAssertTrue(leaseWrapper.contains("case .performCleanup"))
+    XCTAssertTrue(leaseWrapper.contains("await performCoordinatedNSECleanup"))
+    XCTAssertFalse(
+      receiveBody.contains("quickShutdownForNSE"),
+      "A finishing delivery must not close MLS while another delivery still holds a lease"
+    )
+  }
+
+  func testFinalLeaseOwnsSuspensionClearAndEmergencyClose() throws {
+    let source = try notificationServiceSource()
+    let receiveBody = try XCTUnwrap(
+      functionBody(signature: "override func didReceive(", in: source)
+    )
+    let cleanupBody = try XCTUnwrap(
+      functionBody(signature: "private func bestEffortNSECleanup(", in: source)
+    )
+
+    XCTAssertFalse(receiveBody.contains("MLSCoreContext.clearSuspensionFlag()"))
+    XCTAssertTrue(cleanupBody.contains("MLSCoreContext.emergencyCloseAllContexts()"))
+    XCTAssertTrue(cleanupBody.contains("MLSGRDBManager.emergencyCloseAllDatabases(mode: .passive)"))
+    XCTAssertTrue(cleanupBody.contains("MLSCoreContext.clearSuspensionFlag()"))
+  }
+
+  func testExpirationClaimsExceptionalCleanupExactlyOnce() throws {
+    let source = try notificationServiceSource()
+    let expirationBody = try XCTUnwrap(
+      functionBody(signature: "override func serviceExtensionTimeWillExpire()", in: source)
+    )
+    XCTAssertTrue(expirationBody.contains("claimExpirationCleanup()"))
+    XCTAssertTrue(expirationBody.contains("if shouldForceCleanup"))
+    XCTAssertTrue(expirationBody.contains("activeRecipientDIDs"))
+  }
+
+  func testAppStopCleanupUsesExclusiveLeaseOwnedRecipientSet() throws {
+    let source = try notificationServiceSource()
+    let appStopBody = try XCTUnwrap(
+      functionBody(signature: "private func handleAppStopNotification()", in: source)
+    )
+
+    XCTAssertTrue(appStopBody.contains("requestAppStopCleanup()"))
+    XCTAssertTrue(appStopBody.contains("claim.recipientDIDs.sorted()"))
+    XCTAssertTrue(appStopBody.contains("finishAppStopCleanup(claim)"))
+    XCTAssertFalse(source.contains("private var activeRecipientDID"))
+  }
+
+  func testDeinitRemovesDarwinObserverWithoutAssumingMainActorIsolation() throws {
+    let source = try notificationServiceSource()
+    let deinitBody = try XCTUnwrap(functionBody(signature: "deinit", in: source))
+
+    XCTAssertTrue(deinitBody.contains("CFNotificationCenterGetDarwinNotifyCenter()"))
+    XCTAssertTrue(deinitBody.contains("CFNotificationCenterRemoveObserver("))
+    XCTAssertTrue(deinitBody.contains("Unmanaged.passUnretained(self).toOpaque()"))
+    XCTAssertTrue(deinitBody.contains("CFNotificationName(kMLSNSEStopNotification)"))
+    XCTAssertFalse(deinitBody.contains("MainActor.assumeIsolated"))
+    XCTAssertFalse(deinitBody.contains("stopObservingAppStop()"))
+    XCTAssertFalse(deinitBody.contains("isObservingAppStop"))
+  }
+
+  private func notificationServiceSource() throws -> String {
+    try String(
+      contentsOf: repositoryRoot()
+        .appendingPathComponent("NotificationServiceExtension/NotificationService.swift"),
+      encoding: .utf8
+    )
+  }
+
+  private func repositoryRoot() -> URL {
+    URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+  }
+
+  private func functionBody(signature: String, in source: String) -> String? {
+    body(after: signature, in: source)
+  }
+
+  private func body(after signature: String, in source: String) -> String? {
+    guard let signatureRange = source.range(of: signature),
+      let openingBrace = source[signatureRange.upperBound...].firstIndex(of: "{")
+    else {
+      return nil
+    }
+
+    var depth = 0
+    var index = openingBrace
+    while index < source.endIndex {
+      switch source[index] {
+      case "{":
+        depth += 1
+      case "}":
+        depth -= 1
+        if depth == 0 {
+          return String(source[source.index(after: openingBrace)..<index])
+        }
+      default:
+        break
+      }
+      index = source.index(after: index)
+    }
+    return nil
+  }
+}

--- a/CatbirdTests/NSENotificationProcessingLeaseContractTests.swift
+++ b/CatbirdTests/NSENotificationProcessingLeaseContractTests.swift
@@ -214,11 +214,33 @@ final class NSEProcessingLeaseContractTests: XCTestCase {
     let cleanupBody = try XCTUnwrap(
       functionBody(signature: "private func bestEffortNSECleanup(", in: source)
     )
+    let leaseWrapper = try XCTUnwrap(
+      functionBody(signature: "private func withNotificationProcessingLease(", in: source)
+    )
 
     XCTAssertFalse(receiveBody.contains("MLSCoreContext.clearSuspensionFlag()"))
-    XCTAssertTrue(cleanupBody.contains("MLSCoreContext.emergencyCloseAllContexts()"))
+    XCTAssertTrue(leaseWrapper.contains("if lease.startsNewGeneration"))
+    XCTAssertTrue(leaseWrapper.contains("MLSClient.clearSuspensionFlag("))
+    XCTAssertFalse(leaseWrapper.contains("MLSCoreContext.clearSuspensionFlag()"))
+    XCTAssertTrue(cleanupBody.contains("MLSClient.emergencyCloseAllContexts("))
+    XCTAssertFalse(cleanupBody.contains("MLSCoreContext.emergencyCloseAllContexts()"))
     XCTAssertTrue(cleanupBody.contains("MLSGRDBManager.emergencyCloseAllDatabases(mode: .passive)"))
-    XCTAssertTrue(cleanupBody.contains("MLSCoreContext.clearSuspensionFlag()"))
+    XCTAssertTrue(cleanupBody.contains("MLSClient.clearSuspensionFlag("))
+    XCTAssertFalse(cleanupBody.contains("MLSCoreContext.clearSuspensionFlag()"))
+  }
+
+  func testNSEUsesOnlyCoupledLifecycleMutators() throws {
+    let source = try notificationServiceSource()
+
+    for rawMutator in [
+      "MLSCoreContext.markSuspensionInProgress()",
+      "MLSCoreContext.clearSuspensionFlag()",
+      "MLSCoreContext.emergencyCloseAllContexts()",
+    ] {
+      XCTAssertFalse(source.contains(rawMutator), "NSE must not call \(rawMutator)")
+    }
+    XCTAssertTrue(source.contains("MLSClient.clearSuspensionFlag("))
+    XCTAssertTrue(source.contains("MLSClient.emergencyCloseAllContexts("))
   }
 
   func testExpirationClaimsExceptionalCleanupExactlyOnce() throws {
@@ -229,6 +251,9 @@ final class NSEProcessingLeaseContractTests: XCTestCase {
     XCTAssertTrue(expirationBody.contains("claimExpirationCleanup()"))
     XCTAssertTrue(expirationBody.contains("if shouldForceCleanup"))
     XCTAssertTrue(expirationBody.contains("activeRecipientDIDs"))
+    XCTAssertTrue(expirationBody.contains("MLSClient.emergencyCloseAllContexts("))
+    XCTAssertFalse(expirationBody.contains("MLSCoreContext.emergencyCloseAllContexts()"))
+    XCTAssertTrue(expirationBody.contains("MLSGRDBManager.emergencyCloseAllDatabases(mode: .passive)"))
   }
 
   func testAppStopCleanupUsesExclusiveLeaseOwnedRecipientSet() throws {

--- a/NotificationServiceExtension/NotificationService.swift
+++ b/NotificationServiceExtension/NotificationService.swift
@@ -838,7 +838,7 @@ class NotificationService: UNNotificationServiceExtension {
     if shouldForceCleanup {
       // Emergency cleanup before system kills us. NSE must use PASSIVE checkpoint because
       // TRUNCATE can corrupt a WAL that the main app still has open.
-      MLSCoreContext.emergencyCloseAllContexts()
+      MLSClient.emergencyCloseAllContexts(reason: "NSE service extension expiration")
       MLSGRDBManager.emergencyCloseAllDatabases(mode: .passive)
       Self.notificationProcessingLeases.finishExpirationCleanupIfIdle()
     }
@@ -865,7 +865,7 @@ class NotificationService: UNNotificationServiceExtension {
     if lease.startsNewGeneration {
       // A previous notification may have ended through emergency cleanup. Clear only before
       // the first delivery in a new generation, never while another delivery is active.
-      MLSCoreContext.clearSuspensionFlag()
+      MLSClient.clearSuspensionFlag(reason: "NSE new notification processing generation")
     }
 
     await operation()
@@ -935,9 +935,9 @@ class NotificationService: UNNotificationServiceExtension {
     // Log WAL state BEFORE cleanup — if corruption happens during cleanup, this is the "before" snapshot
     MLSGRDBManager.probeWALHealth(for: recipientDid, label: "PRE_CLEANUP")
 
-    // 1. Close all Rust FFI contexts (flushes ratchet state to disk)
-    // NOTE: This sets suspensionInProgress = true internally.
-    MLSCoreContext.emergencyCloseAllContexts()
+    // 1. Close all Rust FFI contexts (flushes ratchet state to disk) through the
+    // coupled lifecycle boundary. This sets both admission gates internally.
+    MLSClient.emergencyCloseAllContexts(reason: "NSE final notification cleanup")
 
     // 2. Close all GRDB DatabasePools registered in the static emergency list.
     // The NSE's own databaseManager uses lightweight DatabaseQueues (nseRead/nseWrite)
@@ -962,7 +962,7 @@ class NotificationService: UNNotificationServiceExtension {
     // the next notification's getContext() call will be blocked — especially when
     // this defer block runs concurrently with the next didReceive (which clears
     // the flag early, but our deferred cleanup re-sets it via emergencyCloseAllContexts).
-    MLSCoreContext.clearSuspensionFlag()
+    MLSClient.clearSuspensionFlag(reason: "NSE final notification cleanup complete")
 
     logger.info("✅ [NSE] Cleanup complete")
   }

--- a/NotificationServiceExtension/NotificationService.swift
+++ b/NotificationServiceExtension/NotificationService.swift
@@ -7,6 +7,7 @@ import PetrelCatbird
 import UserNotifications
 import os.log
 
+@MainActor
 class NotificationService: UNNotificationServiceExtension {
 
   var contentHandler: ((UNNotificationContent) -> Void)?
@@ -19,8 +20,8 @@ class NotificationService: UNNotificationServiceExtension {
   // NSE runs in a separate process from main app - each process needs its own instance.
   // Cross-process coordination is handled by MLSNotificationCoordinator (Darwin + versioning).
   private let databaseManager = MLSGRDBManager()
-  private var activeRecipientDID: String?
   private var isObservingAppStop = false
+  private static let notificationProcessingLeases = NSENotificationProcessingLeases()
 
   // MARK: - Profile Cache (shared via App Group UserDefaults)
 
@@ -35,7 +36,13 @@ class NotificationService: UNNotificationServiceExtension {
   private static let mlsServiceNamespace = "blue.catbird.mls"
 
   deinit {
-    stopObservingAppStop()
+    let center = CFNotificationCenterGetDarwinNotifyCenter()
+    CFNotificationCenterRemoveObserver(
+      center,
+      Unmanaged.passUnretained(self).toOpaque(),
+      CFNotificationName(kMLSNSEStopNotification),
+      nil
+    )
   }
 
   private func startObservingAppStop() {
@@ -58,38 +65,26 @@ class NotificationService: UNNotificationServiceExtension {
     logger.info("🔔 [NSE] Observing app stop notifications")
   }
 
-  private func stopObservingAppStop() {
-    guard isObservingAppStop else { return }
-    let center = CFNotificationCenterGetDarwinNotifyCenter()
-    CFNotificationCenterRemoveObserver(
-      center,
-      Unmanaged.passUnretained(self).toOpaque(),
-      CFNotificationName(kMLSNSEStopNotification),
-
-      nil
-    )
-    isObservingAppStop = false
-  }
-
   private func handleAppStopNotification() {
     Task { @MainActor [weak self] in
       guard let self else { return }
-      guard let userDID = self.activeRecipientDID else {
+      switch await Self.notificationProcessingLeases.requestAppStopCleanup() {
+      case .cleanupAlreadyPerformed:
         self.logger.info("🛑 [NSE] App stop received with no active recipient")
         return
-      }
+      case .performCleanup(let claim):
+        guard Self.notificationProcessingLeases.appStopCleanupIsCurrent(claim) else { return }
+        guard let probeDID = claim.recipientDIDs.sorted().first else { return }
+        guard Self.notificationProcessingLeases.beginAppStopClose(claim) else { return }
 
-      self.logger.warning(
-        "🛑 [NSE] App requested stop - releasing DB for \(userDID.prefix(24))...")
-      await MLSCoreContext.shared.removeContext(for: userDID)
-      let released = await self.databaseManager.releaseConnectionWithoutCheckpoint(
-        for: userDID)
-      if released {
-        self.logger.info("✅ [NSE] Released DB for \(userDID.prefix(24))...")
-      } else {
-        self.logger.warning("⚠️ [NSE] Failed to release DB for \(userDID.prefix(24))...")
+        // No suspension point is allowed between claiming the close and completing it.
+        // Expiration can supersede the app-stop request before this point; afterward this
+        // synchronous emergency close is the generation's one close owner.
+        self.logger.warning(
+          "🛑 [NSE] App requested stop for \(claim.recipientDIDs.count) recipient(s)")
+        self.bestEffortNSECleanup(recipientDid: probeDID)
+        Self.notificationProcessingLeases.finishAppStopCleanup(claim)
       }
-      self.activeRecipientDID = nil
     }
   }
 
@@ -99,9 +94,6 @@ class NotificationService: UNNotificationServiceExtension {
   ) {
     // Ensure custom lexicon types are registered before any decoding
     _ = Self.lexiconRegistration
-
-    // Reset suspension flag from previous notification's cleanup (NSE process reuse)
-    MLSCoreContext.clearSuspensionFlag()
 
     self.contentHandler = contentHandler
     bestAttemptContent = (request.content.mutableCopy() as? UNMutableNotificationContent)
@@ -248,30 +240,26 @@ class NotificationService: UNNotificationServiceExtension {
         "⏭️ [NSE] rustFull authority: avoiding direct NSE MLS decrypt; using cache-only notification path"
       )
       Task { @MainActor in
-        self.activeRecipientDID = recipientDid
-        defer {
-          self.activeRecipientDID = nil
-          self.bestEffortNSECleanup(recipientDid: recipientDid)
-        }
-
-        for attempt in 0..<10 {
-          if await self.deliverCachedNotificationIfAvailable(
-            content: bestAttemptContent,
-            contentHandler: contentHandler,
-            messageId: messageId,
-            convoId: convoId,
-            recipientDid: recipientDid,
-            epoch: epoch,
-            sequenceNumber: sequenceNumber
-          ) {
-            return
+        await self.withNotificationProcessingLease(recipientDid: recipientDid) {
+          for attempt in 0..<10 {
+            if await self.deliverCachedNotificationIfAvailable(
+              content: bestAttemptContent,
+              contentHandler: contentHandler,
+              messageId: messageId,
+              convoId: convoId,
+              recipientDid: recipientDid,
+              epoch: epoch,
+              sequenceNumber: sequenceNumber
+            ) {
+              return
+            }
+            if attempt < 9 { try? await Task.sleep(nanoseconds: 200_000_000) }
           }
-          if attempt < 9 { try? await Task.sleep(nanoseconds: 200_000_000) }
-        }
 
-        bestAttemptContent.title = "New Message"
-        bestAttemptContent.body = "New Encrypted Message"
-        contentHandler(bestAttemptContent)
+          bestAttemptContent.title = "New Message"
+          bestAttemptContent.body = "New Encrypted Message"
+          contentHandler(bestAttemptContent)
+        }
       }
       return
     }
@@ -303,17 +291,7 @@ class NotificationService: UNNotificationServiceExtension {
     let capturedBestAttemptContent = bestAttemptContent
 
     Task { @MainActor in
-      self.activeRecipientDID = recipientDid
-      defer {
-        // ═══════════════════════════════════════════════════════════════
-        // GUARANTEED CLEANUP: Runs on every exit path (cache-hit, error,
-        // timeout, expiry, normal completion). Prevents leaked SQLite
-        // handles in the App Group container that cause 0xdead10cc.
-        // ═══════════════════════════════════════════════════════════════
-        self.activeRecipientDID = nil
-        self.bestEffortNSECleanup(recipientDid: recipientDid)
-      }
-
+      await self.withNotificationProcessingLease(recipientDid: recipientDid) {
       // Check per-conversation mute before expensive decryption
       do {
         let conversation = try await self.databaseManager.nseRead(for: recipientDid) { db in
@@ -843,61 +821,7 @@ class NotificationService: UNNotificationServiceExtension {
         capturedContentHandler(capturedBestAttemptContent)
       }
 
-      // ═══════════════════════════════════════════════════════════════════════════
-      // PHASE 5-6: Enhanced NSE Close Sequence (2024-12)
-      // ═══════════════════════════════════════════════════════════════════════════
-      //
-      // This implements a coordinated close sequence to prevent HMAC check failures
-      // when the main app tries to open the database while NSE is closing:
-      //
-      // 1. Post nseWillClose notification - tells main app to release readers
-      // 2. Wait for app acknowledgment (with timeout)
-      // 3. Use MLSShutdownCoordinator for proper close sequence
-      // 4. Post stateChanged notification - tells app to reload
-      //
-      // ═══════════════════════════════════════════════════════════════════════════
-
-      // Step 1: Post nseWillClose notification
-      self.logger.info("📢 [NSE] Posting nseWillClose notification")
-      let token = MLSNotificationCoordinator.prepareNSECloseHandshake(userDID: recipientDid)
-
-      // Step 2: Wait for app acknowledgment (with timeout)
-      let acked = await MLSNotificationCoordinator.waitForAppAcknowledgment(
-        userDID: recipientDid,
-        token: token,
-        timeout: .milliseconds(1500)
-      )
-      if acked {
-        self.logger.info("✅ [NSE] App acknowledged - waiting for connection release")
-        // Give the app's connection a moment to fully close
-        // The app calls releaseConnectionWithoutCheckpoint which takes ~50ms
-        try? await Task.sleep(nanoseconds: 100_000_000)  // 100ms safety buffer
-      } else {
-        self.logger.warning("⏱️ [NSE] App acknowledgment timeout - skipping close sequence")
-        return
       }
-
-      // Step 3: Use MLSShutdownCoordinator for proper close sequence
-      // This handles: FFI flush → WAL checkpoint → DB release (without 200ms delay for NSE)
-      self.logger.info("🔐 [NSE] Using shutdown coordinator for clean close...")
-      let result = await MLSShutdownCoordinator.shared.quickShutdownForNSE(
-        for: recipientDid, databaseManager: databaseManager)
-      switch result {
-      case .success(let durationMs):
-        self.logger.info("✅ [NSE] Quick shutdown complete in \(durationMs)ms")
-      case .successWithWarnings(let durationMs, let warnings):
-        self.logger.warning(
-          "⚠️ [NSE] Quick shutdown in \(durationMs)ms with \(warnings.count) warning(s)")
-      case .timedOut(let durationMs, let phase):
-        self.logger.warning(
-          "⏱️ [NSE] Quick shutdown timed out at \(phase.rawValue) after \(durationMs)ms")
-      case .failed(let error):
-        self.logger.error("❌ [NSE] Quick shutdown failed: \(error.localizedDescription)")
-      }
-
-      // Step 4: Post stateChanged notification - tells app to reload
-      MLSNotificationCoordinator.postStateChanged()
-      self.logger.info("📢 [NSE] Posted state change notification to main app")
     }
   }
 
@@ -906,15 +830,18 @@ class NotificationService: UNNotificationServiceExtension {
       "⏱️ [NSE] serviceExtensionTimeWillExpire called - system is terminating extension")
 
     // Log WAL state at the moment iOS is killing us — critical for corruption diagnosis
-    if let recipientDid = activeRecipientDID {
+    for recipientDid in Self.notificationProcessingLeases.activeRecipientDIDs.sorted() {
       MLSGRDBManager.probeWALHealth(for: recipientDid, label: "TIME_WILL_EXPIRE")
     }
 
-    // Emergency cleanup before system kills us
-    // CRITICAL: NSE must use PASSIVE checkpoint — TRUNCATE from NSE while main app
-    // has the DB open causes WAL corruption (two processes racing for exclusive WAL access).
-    MLSCoreContext.emergencyCloseAllContexts()
-    MLSGRDBManager.emergencyCloseAllDatabases(mode: .passive)
+    let shouldForceCleanup = Self.notificationProcessingLeases.claimExpirationCleanup()
+    if shouldForceCleanup {
+      // Emergency cleanup before system kills us. NSE must use PASSIVE checkpoint because
+      // TRUNCATE can corrupt a WAL that the main app still has open.
+      MLSCoreContext.emergencyCloseAllContexts()
+      MLSGRDBManager.emergencyCloseAllDatabases(mode: .passive)
+      Self.notificationProcessingLeases.finishExpirationCleanupIfIdle()
+    }
 
     if let contentHandler = contentHandler, let bestAttemptContent = bestAttemptContent {
       if bestAttemptContent.body.isEmpty || bestAttemptContent.body == "Decrypting..." {
@@ -930,11 +857,78 @@ class NotificationService: UNNotificationServiceExtension {
 
   // MARK: - NSE Cleanup
 
+  private func withNotificationProcessingLease(
+    recipientDid: String,
+    operation: @MainActor () async -> Void
+  ) async {
+    let lease = await Self.notificationProcessingLeases.acquire(recipientDID: recipientDid)
+    if lease.startsNewGeneration {
+      // A previous notification may have ended through emergency cleanup. Clear only before
+      // the first delivery in a new generation, never while another delivery is active.
+      MLSCoreContext.clearSuspensionFlag()
+    }
+
+    await operation()
+
+    switch Self.notificationProcessingLeases.release(lease) {
+    case .stillProcessing, .cleanupAlreadyPerformed, .cleanupOwnedElsewhere:
+      return
+    case .performCleanup(let claim):
+      await performCoordinatedNSECleanup(recipientDid: recipientDid, claim: claim)
+      guard Self.notificationProcessingLeases.ordinaryCleanupIsCurrent(claim) else { return }
+      bestEffortNSECleanup(recipientDid: recipientDid)
+      Self.notificationProcessingLeases.finishOrdinaryCleanup(claim)
+    }
+  }
+
+  private func performCoordinatedNSECleanup(
+    recipientDid: String,
+    claim: NSENotificationProcessingLeases.OrdinaryCleanupClaim
+  ) async {
+    logger.info("📢 [NSE] Posting nseWillClose notification")
+    let token = MLSNotificationCoordinator.prepareNSECloseHandshake(userDID: recipientDid)
+    let acked = await MLSNotificationCoordinator.waitForAppAcknowledgment(
+      userDID: recipientDid,
+      token: token,
+      timeout: .milliseconds(1500)
+    )
+    guard acked else {
+      logger.warning("⏱️ [NSE] App acknowledgment timeout - skipping coordinated close")
+      return
+    }
+    guard Self.notificationProcessingLeases.ordinaryCleanupIsCurrent(claim) else { return }
+
+    logger.info("✅ [NSE] App acknowledged - waiting for connection release")
+    try? await Task.sleep(nanoseconds: 100_000_000)
+    guard Self.notificationProcessingLeases.beginOrdinaryClose(claim) else { return }
+
+    logger.info("🔐 [NSE] Using shutdown coordinator for clean close...")
+    let result = await MLSShutdownCoordinator.shared.quickShutdownForNSE(
+      for: recipientDid,
+      databaseManager: databaseManager
+    )
+    switch result {
+    case .success(let durationMs):
+      logger.info("✅ [NSE] Quick shutdown complete in \(durationMs)ms")
+    case .successWithWarnings(let durationMs, let warnings):
+      logger.warning(
+        "⚠️ [NSE] Quick shutdown in \(durationMs)ms with \(warnings.count) warning(s)")
+    case .timedOut(let durationMs, let phase):
+      logger.warning(
+        "⏱️ [NSE] Quick shutdown timed out at \(phase.rawValue) after \(durationMs)ms")
+    case .failed(let error):
+      logger.error("❌ [NSE] Quick shutdown failed: \(error.localizedDescription)")
+    }
+
+    MLSNotificationCoordinator.postStateChanged()
+    logger.info("📢 [NSE] Posted state change notification to main app")
+  }
+
   /// Best-effort cleanup of all process-local MLS state.
   ///
-  /// Called from the processing task's `defer` block to ensure DB handles
-  /// are released even on early-return paths (cache hit, error, timeout).
-  /// Safe to call multiple times — the emergency close APIs are idempotent.
+  /// Called only after the final processing lease drains, so no ordinary cleanup can close
+  /// a context that another delivery is using. Expiration cleanup claims the generation first
+  /// and makes the final ordinary release a no-op.
   private func bestEffortNSECleanup(recipientDid: String) {
     logger.info("🧹 [NSE] Best-effort cleanup for \(recipientDid.prefix(24))...")
 
@@ -1814,8 +1808,8 @@ class NotificationService: UNNotificationServiceExtension {
 
     // Try to find any stored account DID from the shared defaults
     // The main app stores account hashes; we need the actual DID.
-    // Fall back to the active recipient if set during this NSE session.
-    if let activeDid = activeRecipientDID {
+    // Fall back to a lease-owned active recipient from this NSE session.
+    if let activeDid = Self.notificationProcessingLeases.activeRecipientDIDs.sorted().first {
       return activeDid
     }
 


### PR DESCRIPTION
## Summary

- serialize scene/background/account-switch MLS suspension and exact-owner foreground resume
- preserve fail-closed gates through drain, rebind, invalidation, and shutdown failures
- coordinate notification-service leases across the app and NSE with one-shot expiration ownership

## Security invariants

- foreground resume is bound to the exact manager/DID suspension owner and generation
- no admission reopens before tracked FFI work drains and authentication rebind completes
- account switch cannot advance after failed abandonment
- NSE cleanup runs once and cannot race a live notification-processing lease

## Verification at frozen companion head

- Catbird `390457a162498919411a650ae1c8e7f080f765fb`
- CatbirdMLSCore `da9cf40c7d46cd5b90868bc301bdff65e09935fa` (superseded by follow-up review work; exact-pair rerun required before ready)
- fresh build-for-testing: PASS
- focused contract tests: 41/41 PASS
- SwiftLint: exit 0, no serious violations
- independent adversarial review: APPROVE

## Merge gate

Draft until joshlacal/CatbirdMLSCore#11 reaches its final approved head and the complete Catbird/Core exact-pair build and contract matrix is rerun against that head.
