### PR TITLE
Catbird: guard feed glass container on macOS

### DIFF
--- a/Catbird/Features/Feed/Views/FeedsStartPage.swift
+++ b/Catbird/Features/Feed/Views/FeedsStartPage.swift
@@ -1422,7 +1422,7 @@ struct FeedsStartPage: View {
           // pager's history of this bug). Do not wrap anything larger than the
           // title row.
           Group {
-            if #available(iOS 26.0, *) {
+            if #available(iOS 26.0, macOS 26.0, *) {
               GlassEffectContainer(spacing: 8) {
                 feedsTitleRow
               }


### PR DESCRIPTION
## Summary

- guard `GlassEffectContainer` with the required macOS 26 availability check
- add a source-contract regression test for the nearest availability guard
- import Foundation for the test's source-path inspection

## Evidence

- RED policy check failed against the original iOS-only guard
- `FeedsLaunchpadLayoutTests`: 8/8 passed on iOS Simulator, including `glassContainerAvailabilityIncludesMacOS`
- generic native macOS Debug build passed for arm64 and x86_64
- independently adversarially reviewed: APPROVE

## Context

Found while validating the immutable Wave 1 `ffi-w1-690d567b` XCFramework across consumers. The FFI artifact compiled correctly; this was an existing Catbird macOS availability defect.
