### PR TITLE
security: add explicit dev-api E2E routing seam

### DIFF
--- a/Catbird/AppIntents/Support/IntentClientProvider.swift
+++ b/Catbird/AppIntents/Support/IntentClientProvider.swift
@@ -105,7 +105,7 @@ actor IntentClientProvider {
         oauthConfig: oauthConfig,
         namespace: "blue.catbird",
         authMode: .gateway,
-        gatewayURL: URL(string: "https://api.catbird.blue")!,
+        gatewayURL: CatbirdGatewayConfiguration.current.origin,
         userAgent: "Catbird/1.0",
         bskyAppViewDID: "did:web:api.bsky.app#bsky_appview",
         bskyChatDID: "did:web:api.bsky.chat#bsky_chat",

--- a/Catbird/Core/Configuration/CatbirdGatewayConfiguration.swift
+++ b/Catbird/Core/Configuration/CatbirdGatewayConfiguration.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+enum CatbirdGatewayConfigurationError: Error, Equatable {
+  case e2eModeRequired
+  case invalidOverride
+}
+
+/// The single routing decision for foreground Catbird traffic that terminates at Nest or MLS.
+///
+/// Production is immutable. The staging deployment can be selected only by the exact launch
+/// argument emitted by the E2E harness while `--e2e-mode` is also present.
+struct CatbirdGatewayConfiguration: Sendable, Equatable {
+  private enum Deployment: Sendable, Equatable {
+    case production
+    case stagingE2E
+  }
+
+  private static let overrideArgument = "--catbird-gateway-origin"
+  private static let overridePrefix = "\(overrideArgument)="
+  private static let e2eModeArgument = "--e2e-mode"
+
+  private static let productionOrigin = URL(string: "https://api.catbird.blue")!
+  private static let stagingOrigin = URL(string: "https://dev-api.catbird.blue")!
+
+  private let deployment: Deployment
+
+  static let current: Self = {
+    do {
+      return try resolve(arguments: ProcessInfo.processInfo.arguments)
+    } catch {
+      preconditionFailure("Invalid Catbird E2E gateway configuration")
+    }
+  }()
+
+  var origin: URL {
+    switch deployment {
+    case .production:
+      Self.productionOrigin
+    case .stagingE2E:
+      Self.stagingOrigin
+    }
+  }
+
+  /// Nest's service DID, used for gateway-owned foreground XRPC endpoints.
+  var serviceDID: String {
+    switch deployment {
+    case .production:
+      "did:web:api.catbird.blue"
+    case .stagingE2E:
+      "did:web:dev-api.catbird.blue"
+    }
+  }
+
+  /// MLS uses a distinct DID from Nest and must never inherit the Nest service DID.
+  var mlsServiceDID: String? {
+    switch deployment {
+    case .production:
+      nil
+    case .stagingE2E:
+      "did:web:dev-api.catbird.blue:mls"
+    }
+  }
+
+  static func resolve(arguments: [String]) throws -> Self {
+    let overrideArguments = arguments.filter { $0.hasPrefix(overrideArgument) }
+    guard overrideArguments.count <= 1 else {
+      throw CatbirdGatewayConfigurationError.invalidOverride
+    }
+
+    guard let overrideArgument = overrideArguments.first else {
+      return Self(deployment: .production)
+    }
+    guard overrideArgument.hasPrefix(overridePrefix) else {
+      throw CatbirdGatewayConfigurationError.invalidOverride
+    }
+    guard arguments.contains(e2eModeArgument) else {
+      throw CatbirdGatewayConfigurationError.e2eModeRequired
+    }
+
+    let rawOrigin = String(overrideArgument.dropFirst(overridePrefix.count))
+    guard rawOrigin == stagingOrigin.absoluteString else {
+      throw CatbirdGatewayConfigurationError.invalidOverride
+    }
+    return Self(deployment: .stagingE2E)
+  }
+}

--- a/Catbird/Core/State/AppState.swift
+++ b/Catbird/Core/State/AppState.swift
@@ -1284,12 +1284,18 @@ final class AppState {
             return existing
         }
 
-        logger.info("MLS: Creating new API client for production environment (lazy initialization)")
+        let mlsServiceDID = CatbirdGatewayConfiguration.current.mlsServiceDID
+        logger.info("MLS: Creating new API client for configured environment (lazy initialization)")
         // Create MLS client off main actor to avoid blocking UI
         let mlsClient = await Task.detached(priority: .userInitiated) {
+            let environment: MLSEnvironment = if let mlsServiceDID {
+                .custom(serviceDID: mlsServiceDID)
+            } else {
+                .production
+            }
             await MLSAPIClient(
                 client: client,
-                environment: .production
+                environment: environment
             )
         }.value
         mlsAPIClientStorage = mlsClient

--- a/Catbird/Core/State/AppState.swift
+++ b/Catbird/Core/State/AppState.swift
@@ -1293,7 +1293,7 @@ final class AppState {
             } else {
                 .production
             }
-            await MLSAPIClient(
+            return await MLSAPIClient(
                 client: client,
                 environment: environment
             )

--- a/Catbird/Core/State/AuthManager.swift
+++ b/Catbird/Core/State/AuthManager.swift
@@ -124,7 +124,7 @@ enum AuthProgress: Equatable, Sendable {
 /// Handles all authentication-related operations with a clean state machine approach
 @Observable
 final class AuthenticationManager: AuthProgressDelegate {
-  static let gatewayURL = URL(string: "https://api.catbird.blue")!
+  static let gatewayURL = CatbirdGatewayConfiguration.current.origin
 
   // MARK: - Properties
 
@@ -418,7 +418,6 @@ final class AuthenticationManager: AuthProgressDelegate {
             namespace: "blue.catbird",
             authMode: .gateway,
             gatewayURL: AuthenticationManager.gatewayURL,
-//            gatewayURL: URL(string: "https://dev-api.catbird.blue")!,
             userAgent: "Catbird/1.0",
             bskyAppViewDID: appViewDID,
             bskyChatDID: chatDID,
@@ -723,7 +722,6 @@ final class AuthenticationManager: AuthProgressDelegate {
         namespace: "blue.catbird",
         authMode: .gateway,
         gatewayURL: AuthenticationManager.gatewayURL,
-//        gatewayURL: URL(string: "https://dev-api.catbird.blue")!,
         userAgent: "Catbird/1.0",
         bskyAppViewDID: customAppViewDID,
         bskyChatDID: customChatDID,
@@ -1558,7 +1556,6 @@ final class AuthenticationManager: AuthProgressDelegate {
       namespace: "blue.catbird",
       authMode: .gateway,
       gatewayURL: AuthenticationManager.gatewayURL,
-//      gatewayURL: URL(string: "https://dev-api.catbird.blue")!,
       userAgent: "Catbird/1.0",
       bskyAppViewDID: customAppViewDID,
       bskyChatDID: customChatDID,

--- a/Catbird/Features/Chat/Services/ChatHeartbeatManager.swift
+++ b/Catbird/Features/Chat/Services/ChatHeartbeatManager.swift
@@ -12,7 +12,7 @@ final class ChatHeartbeatManager {
   private let logger = Logger(subsystem: "blue.catbird", category: "ChatHeartbeat")
 
   /// Service DID for routing heartbeat calls through Nest.
-  private static let nestServiceDID = "did:web:api.catbird.blue"
+  private static let nestServiceDID = CatbirdGatewayConfiguration.current.serviceDID
 
   /// XRPC endpoint for push heartbeat.
   private static let heartbeatEndpoint = "blue.catbird.bskychat.pushHeartbeat"

--- a/Catbird/Features/Chat/Services/ChatManager.swift
+++ b/Catbird/Features/Chat/Services/ChatManager.swift
@@ -683,7 +683,7 @@ final class ChatManager: StateInvalidationSubscriber {
   // MARK: - Mute Status Server Sync
 
   /// Service DID for routing custom Catbird endpoints through Nest.
-  private static let nestServiceDID = "did:web:api.catbird.blue"
+  private static let nestServiceDID = CatbirdGatewayConfiguration.current.serviceDID
 
   /// Syncs the mute status of a conversation to Nest for server-side push filtering.
   /// This is non-fatal: the 15-minute background sync catches any missed updates.

--- a/Catbird/Features/Notifications/Services/NotificationManager.swift
+++ b/Catbird/Features/Notifications/Services/NotificationManager.swift
@@ -424,14 +424,7 @@ final class NotificationManager: NSObject {
   // MARK: - Initialization
 
   init(
-    notificationServiceDIDString: String = {
-      #if DEBUG
-        "did:web:api.catbird.blue"
-//        "did:web:dev-api.catbird.blue"
-      #else
-        "did:web:api.catbird.blue"
-      #endif
-    }()
+    notificationServiceDIDString: String = CatbirdGatewayConfiguration.current.serviceDID
   ) {
     self.notificationServiceDIDString = notificationServiceDIDString
     super.init()
@@ -3005,30 +2998,16 @@ extension NotificationManager: UNUserNotificationCenterDelegate {
 
     let client: ATProtoClient
     do {
-        #if DEBUG
-        client = try await ATProtoClient(
-          oauthConfig: oauthConfig,
-          namespace: "blue.catbird",
-          authMode: .gateway,
-          gatewayURL: URL(string: "https://api.catbird.blue")!,
-//          gatewayURL: URL(string: "https://dev-api.catbird.blue")!,
-          userAgent: "Catbird/1.0",
-          bskyAppViewDID: "did:web:api.bsky.app#bsky_appview",
-          bskyChatDID: "did:web:api.bsky.chat#bsky_chat",
-          accessGroup: accessGroup
-        )
-        #else
       client = try await ATProtoClient(
         oauthConfig: oauthConfig,
         namespace: "blue.catbird",
         authMode: .gateway,
-        gatewayURL: URL(string: "https://api.catbird.blue")!,
+        gatewayURL: CatbirdGatewayConfiguration.current.origin,
         userAgent: "Catbird/1.0",
         bskyAppViewDID: "did:web:api.bsky.app#bsky_appview",
         bskyChatDID: "did:web:api.bsky.chat#bsky_chat",
         accessGroup: accessGroup
       )
-        #endif
     } catch {
       notificationLogger.error(
         "❌ [FG] Failed to create ATProtoClient: \(error.localizedDescription)")

--- a/Catbird/Features/Notifications/Services/NotificationManager.swift
+++ b/Catbird/Features/Notifications/Services/NotificationManager.swift
@@ -2760,7 +2760,13 @@ extension NotificationManager: UNUserNotificationCenterDelegate {
       return nil
     }
 
-    let apiClient = await MLSAPIClient(client: standaloneClient, environment: .production)
+    let mlsServiceDID = CatbirdGatewayConfiguration.current.mlsServiceDID
+    let environment: MLSEnvironment = if let mlsServiceDID {
+      .custom(serviceDID: mlsServiceDID)
+    } else {
+      .production
+    }
+    let apiClient = await MLSAPIClient(client: standaloneClient, environment: environment)
     notificationLogger.info("🔄 [FG] Created standalone MLS API client for recipient")
     return apiClient
     #else

--- a/CatbirdTests/CatbirdGatewayConfigurationTests.swift
+++ b/CatbirdTests/CatbirdGatewayConfigurationTests.swift
@@ -110,6 +110,8 @@ struct CatbirdGatewayConfigurationTests {
         "CatbirdGatewayConfiguration.current.serviceDID",
       "Catbird/Features/Notifications/Services/NotificationManager.swift":
         "gatewayURL: CatbirdGatewayConfiguration.current.origin",
+      "Catbird/AppIntents/Support/IntentClientProvider.swift":
+        "gatewayURL: CatbirdGatewayConfiguration.current.origin",
       "Catbird/Core/State/AppState.swift":
         "CatbirdGatewayConfiguration.current.mlsServiceDID",
     ]
@@ -128,5 +130,28 @@ struct CatbirdGatewayConfigurationTests {
     )
     #expect(appState.contains(".custom(serviceDID: mlsServiceDID)"))
     #expect(appState.contains("environment: environment"))
+    #expect(appState.contains("return await MLSAPIClient("))
+
+    let notificationManager = try String(
+      contentsOf: repositoryURL.appendingPathComponent(
+        "Catbird/Features/Notifications/Services/NotificationManager.swift"
+      ),
+      encoding: .utf8
+    )
+    let inactiveAccountStart = try #require(
+      notificationManager.range(of: "private func getOrCreateAPIClient(for userDid: String)")
+    )
+    let inactiveAccountEnd = try #require(
+      notificationManager.range(
+        of: "private func checkGroupExists",
+        range: inactiveAccountStart.upperBound..<notificationManager.endIndex
+      )
+    )
+    let inactiveAccountSource = notificationManager[
+      inactiveAccountStart.lowerBound..<inactiveAccountEnd.lowerBound
+    ]
+    #expect(inactiveAccountSource.contains("CatbirdGatewayConfiguration.current.mlsServiceDID"))
+    #expect(inactiveAccountSource.contains(".custom(serviceDID: mlsServiceDID)"))
+    #expect(!inactiveAccountSource.contains("environment: .production"))
   }
 }

--- a/CatbirdTests/CatbirdGatewayConfigurationTests.swift
+++ b/CatbirdTests/CatbirdGatewayConfigurationTests.swift
@@ -1,0 +1,132 @@
+import Foundation
+import Testing
+
+@testable import Catbird
+
+@Suite("Catbird gateway configuration")
+struct CatbirdGatewayConfigurationTests {
+  @Test("production is the immutable default")
+  func productionDefault() throws {
+    let configuration = try CatbirdGatewayConfiguration.resolve(arguments: [])
+
+    #expect(configuration.origin == URL(string: "https://api.catbird.blue")!)
+    #expect(configuration.serviceDID == "did:web:api.catbird.blue")
+    #expect(configuration.mlsServiceDID == nil)
+
+    let e2eWithoutOverride = try CatbirdGatewayConfiguration.resolve(arguments: [
+      "Catbird", "--e2e-mode",
+    ])
+    #expect(e2eWithoutOverride == configuration)
+  }
+
+  @Test("the exact dev-api origin is available only in E2E mode")
+  func exactStagingOverride() throws {
+    let configuration = try CatbirdGatewayConfiguration.resolve(arguments: [
+      "Catbird",
+      "--e2e-mode",
+      "--catbird-gateway-origin=https://dev-api.catbird.blue",
+    ])
+
+    #expect(configuration.origin == URL(string: "https://dev-api.catbird.blue")!)
+    #expect(configuration.serviceDID == "did:web:dev-api.catbird.blue")
+    #expect(configuration.mlsServiceDID == "did:web:dev-api.catbird.blue:mls")
+  }
+
+  @Test("a staging override without E2E mode fails closed")
+  func stagingRequiresE2EMode() {
+    #expect(throws: CatbirdGatewayConfigurationError.e2eModeRequired) {
+      try CatbirdGatewayConfiguration.resolve(arguments: [
+        "Catbird",
+        "--catbird-gateway-origin=https://dev-api.catbird.blue",
+      ])
+    }
+  }
+
+  @Test(
+    "unapproved and non-canonical gateway origins fail closed",
+    arguments: [
+      "https://evil.example",
+      "http://dev-api.catbird.blue",
+      "https://user@dev-api.catbird.blue",
+      "https://user:password@dev-api.catbird.blue",
+      "https://dev-api.catbird.blue#fragment",
+      "https://dev-api.catbird.blue:443",
+      "https://dev-api.catbird.blue:444",
+      "https://dev-api.catbird.blue.evil.example",
+      "https://dev-api.catbird.blue/",
+      "https://dev-api.catbird.blue?query=value",
+      "https://DEV-API.catbird.blue",
+      "https://dev-api.catbird.blue%2eevil.example",
+    ]
+  )
+  func rejectsOriginTricks(origin: String) {
+    #expect(throws: CatbirdGatewayConfigurationError.invalidOverride) {
+      try CatbirdGatewayConfiguration.resolve(arguments: [
+        "Catbird",
+        "--e2e-mode",
+        "--catbird-gateway-origin=\(origin)",
+      ])
+    }
+  }
+
+  @Test("duplicate selectors fail closed")
+  func duplicateSelectors() {
+    #expect(throws: CatbirdGatewayConfigurationError.invalidOverride) {
+      try CatbirdGatewayConfiguration.resolve(arguments: [
+        "Catbird",
+        "--e2e-mode",
+        "--catbird-gateway-origin=https://dev-api.catbird.blue",
+        "--catbird-gateway-origin=https://dev-api.catbird.blue",
+      ])
+    }
+  }
+
+  @Test("malformed selector syntax fails closed")
+  func malformedSelectorSyntax() {
+    for argument in [
+      "--catbird-gateway-origin",
+      "--catbird-gateway-origin:https://dev-api.catbird.blue",
+      "--catbird-gateway-origin-extra=https://dev-api.catbird.blue",
+    ] {
+      #expect(throws: CatbirdGatewayConfigurationError.invalidOverride) {
+        try CatbirdGatewayConfiguration.resolve(arguments: [
+          "Catbird", "--e2e-mode", argument,
+        ])
+      }
+    }
+  }
+
+  @Test("foreground gateway and MLS call sites use the centralized decision")
+  func foregroundWiring() throws {
+    let repositoryURL = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+    let expectedFragments = [
+      "Catbird/Core/State/AuthManager.swift":
+        "static let gatewayURL = CatbirdGatewayConfiguration.current.origin",
+      "Catbird/Features/Chat/Services/ChatManager.swift":
+        "CatbirdGatewayConfiguration.current.serviceDID",
+      "Catbird/Features/Chat/Services/ChatHeartbeatManager.swift":
+        "CatbirdGatewayConfiguration.current.serviceDID",
+      "Catbird/Features/Notifications/Services/NotificationManager.swift":
+        "gatewayURL: CatbirdGatewayConfiguration.current.origin",
+      "Catbird/Core/State/AppState.swift":
+        "CatbirdGatewayConfiguration.current.mlsServiceDID",
+    ]
+
+    for (path, fragment) in expectedFragments {
+      let source = try String(
+        contentsOf: repositoryURL.appendingPathComponent(path),
+        encoding: .utf8
+      )
+      #expect(source.contains(fragment), "Missing centralized routing in \(path)")
+    }
+
+    let appState = try String(
+      contentsOf: repositoryURL.appendingPathComponent("Catbird/Core/State/AppState.swift"),
+      encoding: .utf8
+    )
+    #expect(appState.contains(".custom(serviceDID: mlsServiceDID)"))
+    #expect(appState.contains("environment: environment"))
+  }
+}


### PR DESCRIPTION
## Summary
- add a fail-closed, E2E-only selector for the exact `https://dev-api.catbird.blue` Nest origin
- route Nest and MLS clients through one centralized environment decision
- close App Intents and inactive-notification production routing bypasses
- preserve production defaults outside explicit E2E mode

## Verification
- independent adversarial review: APPROVE
- `CatbirdGatewayConfigurationTests`: 17/17 passed
- full Catbird `build-for-testing`: passed on iPhone 17 Pro simulator
- built against merged CatbirdMLSCore PR #15 and verified immutable `ffi-w2-bd2fe34d` artifact

## Runtime gate
This seam is required for isolated authenticated OAuth and MLS chat/group E2E against `dev-api`; it does not change production routing by default.