### PR TITLE
security: bind staging MLS to advertised service DID

### DIFF
--- a/Catbird/Core/Configuration/CatbirdGatewayConfiguration.swift
+++ b/Catbird/Core/Configuration/CatbirdGatewayConfiguration.swift
@@ -57,7 +57,7 @@ struct CatbirdGatewayConfiguration: Sendable, Equatable {
     case .production:
       nil
     case .stagingE2E:
-      "did:web:dev-api.catbird.blue:mls"
+      "did:web:dev-api.catbird.blue:mls#atproto_mls"
     }
   }
 

--- a/CatbirdTests/CatbirdGatewayConfigurationTests.swift
+++ b/CatbirdTests/CatbirdGatewayConfigurationTests.swift
@@ -29,7 +29,9 @@ struct CatbirdGatewayConfigurationTests {
 
     #expect(configuration.origin == URL(string: "https://dev-api.catbird.blue")!)
     #expect(configuration.serviceDID == "did:web:dev-api.catbird.blue")
-    #expect(configuration.mlsServiceDID == "did:web:dev-api.catbird.blue:mls")
+    #expect(
+      configuration.mlsServiceDID == "did:web:dev-api.catbird.blue:mls#atproto_mls"
+    )
   }
 
   @Test("a staging override without E2E mode fails closed")


### PR DESCRIPTION
## Summary
- select the exact `#atproto_mls` service DID advertised by `dev-api`
- preserve production defaults and exact fail-closed staging selection
- update focused configuration coverage

## Verification
- `CatbirdGatewayConfigurationTests`: 18/18 passed on iOS Simulator
- independent adversarial review: APPROVE
- live `https://dev-api.catbird.blue/mls/did.json` advertises the matching service fragment

## Scope
Two files only; no production endpoint or default changes.