### PR TITLE
security: complete one-time OAuth callback exchange

### DIFF
--- a/Catbird/App/CatbirdApp.swift
+++ b/Catbird/App/CatbirdApp.swift
@@ -1294,8 +1294,7 @@ NavigationFontConfig.applyEarlyNavigationBarAppearance()
           )
 
           // Check for gateway BFF callback (Universal Link from catbird.blue)
-          // Temporary compatibility accepts Nest's legacy session_id fragment callback.
-          // Remove this path only after the hotfix design document's rollout gate is met.
+          // Gateway redirects with a one-time exchange code in the query.
           if url.host == "catbird.blue" && url.path == "/oauth/callback" {
             logger.info("Gateway OAuth callback detected")
             Task {

--- a/Catbird/Core/Networking/GatewayOAuthExchange.swift
+++ b/Catbird/Core/Networking/GatewayOAuthExchange.swift
@@ -1,116 +1,498 @@
 import Foundation
+import Security
 
-enum GatewayOAuthLegacyCallbackError: Error, Equatable {
+enum GatewayOAuthExchangeError: Error, Equatable {
   case configuration
   case flowInProgress
   case unauthorized
 }
 
-/// Temporary compatibility for Nest's legacy fragment callback.
-/// Remove only after the conditions in the hotfix design document are met.
-actor GatewayOAuthLegacyCallback {
-  static let attemptLifetime: TimeInterval = 60
+/// Owns the in-memory proof that binds a native browser login to its callback.
+/// A pending nonce is removed before callback validation or network I/O so every
+/// callback attempt is single-use locally, including malformed attempts.
+actor GatewayOAuthExchange {
+  typealias Sender = @Sendable (URLRequest) async throws -> (Data, URLResponse)
+  typealias DeadlineWaiter = @Sendable () async throws -> Void
 
+  static let maximumResponseBytes = 8 * 1024
+
+  private let gatewayURL: URL
   private let callbackURL: URL
+  private let callbackOrigin: String
   private let uptime: @Sendable () -> TimeInterval
-  private var pendingCreatedAt: TimeInterval?
+  private let send: Sender
+  private let waitForDeadline: DeadlineWaiter
+  private var pending: PendingLogin?
+  private var flowGeneration: UInt64 = 0
+
+  init(gatewayURL: URL, callbackURL: URL) {
+    let transport = GatewayOAuthExchangeTransport(maximumBytes: Self.maximumResponseBytes)
+    self.gatewayURL = gatewayURL
+    self.callbackURL = callbackURL
+    self.callbackOrigin = Self.origin(of: callbackURL) ?? ""
+    self.uptime = { ProcessInfo.processInfo.systemUptime }
+    self.send = { request in try await transport.send(request) }
+    self.waitForDeadline = {
+      try await Task.sleep(for: .seconds(15))
+    }
+  }
 
   init(
+    gatewayURL: URL,
     callbackURL: URL,
-    uptime: @escaping @Sendable () -> TimeInterval = {
-      ProcessInfo.processInfo.systemUptime
+    uptime: @escaping @Sendable () -> TimeInterval = { ProcessInfo.processInfo.systemUptime },
+    send: @escaping Sender,
+    waitForDeadline: @escaping DeadlineWaiter = {
+      try await Task.sleep(for: .seconds(15))
     }
   ) {
+    self.gatewayURL = gatewayURL
     self.callbackURL = callbackURL
+    self.callbackOrigin = Self.origin(of: callbackURL) ?? ""
     self.uptime = uptime
+    self.send = send
+    self.waitForDeadline = waitForDeadline
   }
 
   func prepareLogin(_ loginURL: URL) throws -> URL {
-    if let pendingCreatedAt,
-      uptime() - pendingCreatedAt <= Self.attemptLifetime
-    {
-      throw GatewayOAuthLegacyCallbackError.flowInProgress
+    if let pending, uptime() - pending.createdAt <= 60 {
+      throw GatewayOAuthExchangeError.flowInProgress
     }
-    pendingCreatedAt = nil
+    pending = nil
 
-    guard Self.isValidConfiguredCallback(callbackURL) else {
-      throw GatewayOAuthLegacyCallbackError.configuration
+    guard Self.isHTTPSOrigin(gatewayURL),
+      Self.isHTTPSOrigin(callbackURL),
+      callbackURL.user == nil,
+      callbackURL.password == nil,
+      callbackURL.query == nil,
+      callbackURL.fragment == nil,
+      !callbackOrigin.isEmpty,
+      Self.origin(of: loginURL) == Self.origin(of: gatewayURL),
+      var components = URLComponents(url: loginURL, resolvingAgainstBaseURL: false)
+    else {
+      pending = nil
+      throw GatewayOAuthExchangeError.configuration
     }
-    pendingCreatedAt = uptime()
-    return loginURL
+
+    let nonce = try Self.randomNonce()
+    var queryItems = (components.queryItems ?? []).filter {
+      $0.name != "browser_nonce" && $0.name != "redirect_to"
+    }
+    queryItems.append(URLQueryItem(name: "browser_nonce", value: nonce))
+    queryItems.append(URLQueryItem(name: "redirect_to", value: callbackURL.absoluteString))
+    components.queryItems = queryItems
+
+    guard let boundURL = components.url else {
+      pending = nil
+      throw GatewayOAuthExchangeError.configuration
+    }
+    flowGeneration &+= 1
+    pending = PendingLogin(
+      nonce: nonce,
+      createdAt: uptime(),
+      generation: flowGeneration
+    )
+    return boundURL
   }
 
-  func consume(_ callback: URL) throws -> String {
-    guard let createdAt = pendingCreatedAt else {
-      throw GatewayOAuthLegacyCallbackError.unauthorized
+  func redeem(_ callback: URL) async throws -> String {
+    guard let pending else {
+      throw GatewayOAuthExchangeError.unauthorized
     }
-    pendingCreatedAt = nil
+    self.pending = nil
 
-    guard uptime() - createdAt <= Self.attemptLifetime,
-      let sessionID = Self.validatedSessionID(from: callback, expected: callbackURL)
-    else {
-      throw GatewayOAuthLegacyCallbackError.unauthorized
+    guard uptime() - pending.createdAt <= 60 else {
+      throw GatewayOAuthExchangeError.unauthorized
     }
-    return sessionID
+
+    guard let code = Self.validatedCode(from: callback, expected: callbackURL) else {
+      throw GatewayOAuthExchangeError.unauthorized
+    }
+
+    var request = URLRequest(url: gatewayURL.appendingPathComponent("auth/exchange"))
+    request.httpMethod = "POST"
+    request.timeoutInterval = 15
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    request.setValue(callbackOrigin, forHTTPHeaderField: "Origin")
+    request.httpBody = try? JSONEncoder().encode(
+      ExchangeRequest(code: code, browserNonce: pending.nonce))
+
+    guard request.httpBody != nil else {
+      throw GatewayOAuthExchangeError.unauthorized
+    }
+
+    do {
+      let (data, response) = try await sendWithAbsoluteDeadline(request)
+      guard pending.generation == flowGeneration else {
+        throw GatewayOAuthExchangeError.unauthorized
+      }
+      guard let http = response as? HTTPURLResponse,
+        (200..<300).contains(http.statusCode),
+        data.count <= Self.maximumResponseBytes,
+        http.value(forHTTPHeaderField: "Content-Type")?.lowercased()
+          .hasPrefix("application/json") == true,
+        let payload = try? JSONDecoder().decode(ExchangeResponse.self, from: data),
+        Self.isValidSessionID(payload.sessionID)
+      else {
+        throw GatewayOAuthExchangeError.unauthorized
+      }
+      return payload.sessionID
+    } catch is GatewayOAuthExchangeError {
+      throw GatewayOAuthExchangeError.unauthorized
+    } catch {
+      throw GatewayOAuthExchangeError.unauthorized
+    }
   }
 
   func cancelPendingLogin() {
-    pendingCreatedAt = nil
+    flowGeneration &+= 1
+    pending = nil
   }
 
-  private static func validatedSessionID(from callback: URL, expected: URL) -> String? {
-    guard let callbackComponents = URLComponents(
-      url: callback,
-      resolvingAgainstBaseURL: false
-    ),
-      let expectedComponents = URLComponents(
-        url: expected,
-        resolvingAgainstBaseURL: false
-      ),
-      callback.scheme?.lowercased() == expected.scheme?.lowercased(),
+  private func sendWithAbsoluteDeadline(_ request: URLRequest) async throws -> (Data, URLResponse) {
+    let race = GatewayOAuthExchangeRace()
+    let sender = send
+    let deadline = waitForDeadline
+
+    let sendTask = Task.detached {
+      do {
+        let (data, response) = try await sender(request)
+        race.resolve(.response(GatewayOAuthExchangeResponse(data: data, response: response)))
+      } catch {
+        race.resolve(.failed)
+      }
+    }
+    let deadlineTask = Task.detached {
+      do {
+        try await deadline()
+        race.resolve(.deadline)
+      } catch {
+        if !Task.isCancelled {
+          race.resolve(.failed)
+        }
+      }
+    }
+
+    let outcome = await withTaskCancellationHandler {
+      await race.wait()
+    } onCancel: {
+      sendTask.cancel()
+      deadlineTask.cancel()
+      race.resolve(.cancelled)
+    }
+
+    sendTask.cancel()
+    deadlineTask.cancel()
+
+    guard case .response(let response) = outcome else {
+      throw GatewayOAuthExchangeError.unauthorized
+    }
+    return (response.data, response.response)
+  }
+
+  private static func randomNonce() throws -> String {
+    var bytes = [UInt8](repeating: 0, count: 32)
+    guard SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes) == errSecSuccess else {
+      throw GatewayOAuthExchangeError.configuration
+    }
+    return Data(bytes).base64EncodedString()
+      .replacingOccurrences(of: "+", with: "-")
+      .replacingOccurrences(of: "/", with: "_")
+      .replacingOccurrences(of: "=", with: "")
+  }
+
+  private static func validatedCode(from callback: URL, expected: URL) -> String? {
+    guard callback.scheme?.lowercased() == expected.scheme?.lowercased(),
       callback.host?.lowercased() == expected.host?.lowercased(),
       effectivePort(of: callback) == effectivePort(of: expected),
-      callbackComponents.percentEncodedPath == expectedComponents.percentEncodedPath,
+      callback.path == expected.path,
       callback.user == nil,
       callback.password == nil,
-      callbackComponents.percentEncodedQuery == nil,
-      let rawFragment = callbackComponents.percentEncodedFragment
+      callback.fragment == nil,
+      let components = URLComponents(url: callback, resolvingAgainstBaseURL: false),
+      let queryItems = components.queryItems,
+      queryItems.count == 1,
+      queryItems[0].name == "code",
+      let code = queryItems[0].value,
+      code.count == 43,
+      code.utf8.allSatisfy({ byte in
+        (65...90).contains(byte) || (97...122).contains(byte) || (48...57).contains(byte)
+          || byte == 45 || byte == 95
+      })
     else {
       return nil
     }
-
-    let items = rawFragment.split(separator: "&", omittingEmptySubsequences: false)
-    guard items.count == 1 else { return nil }
-
-    let parts = items[0].split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
-    guard parts.count == 2, parts[0] == "session_id" else { return nil }
-
-    guard let sessionID = String(parts[1]).removingPercentEncoding else { return nil }
-    guard let uuid = UUID(uuidString: sessionID),
-      uuid.uuidString.lowercased() == sessionID
-    else {
-      return nil
-    }
-    return sessionID
-  }
-
-  private static func isValidConfiguredCallback(_ url: URL) -> Bool {
-    guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
-      return false
-    }
-
-    return url.scheme?.lowercased() == "https"
-      && url.host?.lowercased() == "catbird.blue"
-      && url.user == nil
-      && url.password == nil
-      && components.percentEncodedQuery == nil
-      && components.percentEncodedFragment == nil
-      && components.percentEncodedPath == "/oauth/callback"
-      && effectivePort(of: url) == 443
+    return code
   }
 
   private static func effectivePort(of url: URL) -> Int? {
     if let port = url.port { return port }
     return url.scheme?.lowercased() == "https" ? 443 : nil
+  }
+
+  private static func isValidSessionID(_ sessionID: String) -> Bool {
+    guard let uuid = UUID(uuidString: sessionID) else { return false }
+    return uuid.uuidString.lowercased() == sessionID
+  }
+
+  private static func isHTTPSOrigin(_ url: URL) -> Bool {
+    url.scheme?.lowercased() == "https" && url.host != nil && url.user == nil && url.password == nil
+  }
+
+  private static func origin(of url: URL) -> String? {
+    guard isHTTPSOrigin(url), let host = url.host?.lowercased() else { return nil }
+    if let port = url.port, port != 443 {
+      return "https://\(host):\(port)"
+    }
+    return "https://\(host)"
+  }
+
+  private struct PendingLogin {
+    let nonce: String
+    let createdAt: TimeInterval
+    let generation: UInt64
+  }
+}
+
+private struct GatewayOAuthExchangeResponse: @unchecked Sendable {
+  let data: Data
+  let response: URLResponse
+}
+
+private final class GatewayOAuthExchangeRace: @unchecked Sendable {
+  enum Outcome: @unchecked Sendable {
+    case response(GatewayOAuthExchangeResponse)
+    case deadline
+    case failed
+    case cancelled
+  }
+
+  private let lock = NSLock()
+  private var outcome: Outcome?
+  private var continuation: CheckedContinuation<Outcome, Never>?
+
+  func resolve(_ outcome: Outcome) {
+    var continuationToResume: CheckedContinuation<Outcome, Never>?
+    lock.withLock {
+      guard self.outcome == nil else { return }
+      self.outcome = outcome
+      continuationToResume = continuation
+      continuation = nil
+    }
+    continuationToResume?.resume(returning: outcome)
+  }
+
+  func wait() async -> Outcome {
+    await withCheckedContinuation { continuation in
+      var immediate: Outcome?
+      lock.withLock {
+        if let outcome {
+          immediate = outcome
+        } else {
+          precondition(self.continuation == nil)
+          self.continuation = continuation
+        }
+      }
+      if let immediate {
+        continuation.resume(returning: immediate)
+      }
+    }
+  }
+}
+
+final class GatewayOAuthExchangeTransport: @unchecked Sendable {
+  static let redirectTarget: URLRequest? = nil
+
+  private let delegate: GatewayOAuthExchangeSessionDelegate
+  private let session: URLSession
+  var hasInitializedSession: Bool { true }
+
+  init(maximumBytes: Int, protocolClasses: [AnyClass]? = nil) {
+    let delegate = GatewayOAuthExchangeSessionDelegate(maximumBytes: maximumBytes)
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.httpShouldSetCookies = false
+    configuration.httpCookieAcceptPolicy = .never
+    configuration.urlCache = nil
+    configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+    if let protocolClasses {
+      configuration.protocolClasses = protocolClasses
+    }
+    self.delegate = delegate
+    self.session = URLSession(configuration: configuration, delegate: delegate, delegateQueue: nil)
+  }
+
+  func send(_ request: URLRequest) async throws -> (Data, URLResponse) {
+    let cancellation = GatewayOAuthExchangeTaskCancellation()
+    return try await withTaskCancellationHandler {
+      try await withCheckedThrowingContinuation { continuation in
+        let task = session.dataTask(with: request)
+        delegate.register(task: task, continuation: continuation)
+        guard cancellation.installAndResume(task) else {
+          delegate.cancel(task: task)
+          return
+        }
+      }
+    } onCancel: {
+      cancellation.cancel()
+    }
+  }
+
+  static func responseDisposition(hasPendingRequest: Bool) -> URLSession.ResponseDisposition {
+    hasPendingRequest ? .allow : .cancel
+  }
+
+  static func append(_ chunk: Data, to data: inout Data, maximumBytes: Int) throws {
+    guard data.count <= maximumBytes, chunk.count <= maximumBytes - data.count else {
+      throw GatewayOAuthExchangeError.unauthorized
+    }
+    data.append(chunk)
+  }
+}
+
+private final class GatewayOAuthExchangeSessionDelegate: NSObject, URLSessionDataDelegate,
+  @unchecked Sendable
+{
+  private struct PendingRequest {
+    let continuation: CheckedContinuation<(Data, URLResponse), Error>
+    var data = Data()
+    var response: URLResponse?
+  }
+
+  private let maximumBytes: Int
+  private let lock = NSLock()
+  private var requests: [Int: PendingRequest] = [:]
+
+  init(maximumBytes: Int) {
+    self.maximumBytes = maximumBytes
+  }
+
+  func register(
+    task: URLSessionTask,
+    continuation: CheckedContinuation<(Data, URLResponse), Error>
+  ) {
+    lock.withLock {
+      requests[task.taskIdentifier] = PendingRequest(continuation: continuation)
+    }
+  }
+
+  func cancel(task: URLSessionTask) {
+    let pending = lock.withLock { requests.removeValue(forKey: task.taskIdentifier) }
+    task.cancel()
+    pending?.continuation.resume(throwing: CancellationError())
+  }
+
+  func urlSession(
+    _ session: URLSession,
+    task: URLSessionTask,
+    willPerformHTTPRedirection response: HTTPURLResponse,
+    newRequest request: URLRequest,
+    completionHandler: @escaping (URLRequest?) -> Void
+  ) {
+    completionHandler(GatewayOAuthExchangeTransport.redirectTarget)
+  }
+
+  func urlSession(
+    _ session: URLSession,
+    dataTask: URLSessionDataTask,
+    didReceive response: URLResponse,
+    completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+  ) {
+    var rejected: PendingRequest?
+    let hasPendingRequest = lock.withLock {
+      guard var pending = requests[dataTask.taskIdentifier] else { return false }
+      if response.expectedContentLength > maximumBytes {
+        rejected = requests.removeValue(forKey: dataTask.taskIdentifier)
+      } else {
+        pending.response = response
+        requests[dataTask.taskIdentifier] = pending
+      }
+      return true
+    }
+    if let rejected {
+      rejected.continuation.resume(throwing: GatewayOAuthExchangeError.unauthorized)
+      completionHandler(.cancel)
+    } else {
+      completionHandler(
+        GatewayOAuthExchangeTransport.responseDisposition(
+          hasPendingRequest: hasPendingRequest))
+    }
+  }
+
+  func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+    var rejected: PendingRequest?
+    lock.withLock {
+      guard var pending = requests[dataTask.taskIdentifier] else { return }
+      do {
+        try GatewayOAuthExchangeTransport.append(
+          data, to: &pending.data, maximumBytes: maximumBytes)
+        requests[dataTask.taskIdentifier] = pending
+      } catch {
+        rejected = requests.removeValue(forKey: dataTask.taskIdentifier)
+      }
+    }
+    if let rejected {
+      dataTask.cancel()
+      rejected.continuation.resume(throwing: GatewayOAuthExchangeError.unauthorized)
+    }
+  }
+
+  func urlSession(
+    _ session: URLSession,
+    task: URLSessionTask,
+    didCompleteWithError error: Error?
+  ) {
+    let pending = lock.withLock { requests.removeValue(forKey: task.taskIdentifier) }
+    guard let pending else { return }
+    if let error {
+      pending.continuation.resume(throwing: error)
+    } else if let response = pending.response {
+      pending.continuation.resume(returning: (pending.data, response))
+    } else {
+      pending.continuation.resume(throwing: GatewayOAuthExchangeError.unauthorized)
+    }
+  }
+}
+
+private final class GatewayOAuthExchangeTaskCancellation: @unchecked Sendable {
+  private let lock = NSLock()
+  private var isCancelled = false
+  private var task: URLSessionTask?
+
+  func installAndResume(_ task: URLSessionTask) -> Bool {
+    lock.withLock {
+      guard !isCancelled else { return false }
+      self.task = task
+      task.resume()
+      return true
+    }
+  }
+
+  func cancel() {
+    let taskToCancel = lock.withLock {
+      isCancelled = true
+      let task = task
+      self.task = nil
+      return task
+    }
+    taskToCancel?.cancel()
+  }
+}
+
+private struct ExchangeRequest: Encodable {
+  let code: String
+  let browserNonce: String
+
+  enum CodingKeys: String, CodingKey {
+    case code
+    case browserNonce = "browser_nonce"
+  }
+}
+
+private struct ExchangeResponse: Decodable {
+  let sessionID: String
+
+  enum CodingKeys: String, CodingKey {
+    case sessionID = "session_id"
   }
 }

--- a/Catbird/Core/State/AuthManager.swift
+++ b/Catbird/Core/State/AuthManager.swift
@@ -196,7 +196,8 @@ final class AuthenticationManager: AuthProgressDelegate {
   )
 
   @ObservationIgnored
-  private let gatewayOAuthLegacyCallback = GatewayOAuthLegacyCallback(
+  private let gatewayOAuthExchange = GatewayOAuthExchange(
+    gatewayURL: AuthenticationManager.gatewayURL,
     callbackURL: URL(string: "https://catbird.blue/oauth/callback")!
   )
 
@@ -786,7 +787,7 @@ final class AuthenticationManager: AuthProgressDelegate {
             )
           }
 
-          let boundAuthURL = try await gatewayOAuthLegacyCallback.prepareLogin(authURL)
+          let boundAuthURL = try await gatewayOAuthExchange.prepareLogin(authURL)
           logger.info("OAuth URL generated successfully")
           await self.updateState(.authenticating(progress: .openingBrowser))
           return boundAuthURL
@@ -1104,7 +1105,7 @@ final class AuthenticationManager: AuthProgressDelegate {
     }
   }
 
-  /// Handle a gateway callback using the temporary legacy compatibility path.
+  /// Handle a gateway callback by atomically exchanging its one-time code.
   @MainActor
   func handleGatewayCallback(_ url: URL) async throws {
     logger.info("🔗 [GATEWAY] Processing gateway callback")
@@ -1126,7 +1127,7 @@ final class AuthenticationManager: AuthProgressDelegate {
     do {
       updateState(.authenticating(progress: .creatingSession))
 
-      let sessionID = try await gatewayOAuthLegacyCallback.consume(url)
+      let sessionID = try await gatewayOAuthExchange.redeem(url)
       var internalCallback = URLComponents()
       internalCallback.scheme = "https"
       internalCallback.host = "catbird.blue"
@@ -1187,7 +1188,7 @@ final class AuthenticationManager: AuthProgressDelegate {
 
   @MainActor
   func cancelGatewayOAuthFlow() async {
-    await gatewayOAuthLegacyCallback.cancelPendingLogin()
+    await gatewayOAuthExchange.cancelPendingLogin()
   }
 
   /// Logout the current user
@@ -1870,7 +1871,7 @@ final class AuthenticationManager: AuthProgressDelegate {
       let authURL = try await withTimeout(timeout: networkTimeout) {
         try await client.startOAuthFlow(identifier: handle)
       }
-      let boundAuthURL = try await gatewayOAuthLegacyCallback.prepareLogin(authURL)
+      let boundAuthURL = try await gatewayOAuthExchange.prepareLogin(authURL)
       self.logger.debug("OAuth URL generated for new account")
 
       updateState(.authenticating(progress: .openingBrowser))
@@ -1893,14 +1894,14 @@ final class AuthenticationManager: AuthProgressDelegate {
     }
   }
 
-  /// Start gateway account creation with the same legacy callback validation as login.
+  /// Start gateway account creation with the same native nonce binding as login.
   @MainActor
   func startSignUp(pdsURL: URL) async throws -> URL {
     guard let client else {
       throw AuthError.clientNotInitialized
     }
     let authURL = try await client.startSignUpFlow(pdsURL: pdsURL)
-    return try await gatewayOAuthLegacyCallback.prepareLogin(authURL)
+    return try await gatewayOAuthExchange.prepareLogin(authURL)
   }
 
   /// Get current active account info

--- a/Catbird/Features/Auth/Views/LoginView.swift
+++ b/Catbird/Features/Auth/Views/LoginView.swift
@@ -914,7 +914,7 @@ struct LoginView: View {
     private func cancelAuthentication() {
         logger.warning("User cancelled authentication")
         
-        // Cancel the authentication task and invalidate any prepared legacy callback.
+        // Cancel the authentication task and invalidate any prepared exchange attempt.
         cancelAuthenticationTaskAndPendingAttempt()
         
         // Reset state

--- a/CatbirdTests/GatewayOAuthExchangeTests.swift
+++ b/CatbirdTests/GatewayOAuthExchangeTests.swift
@@ -3,132 +3,38 @@ import Testing
 
 @testable import Catbird
 
-@Suite("Temporary gateway OAuth legacy callback compatibility")
+@Suite("Gateway OAuth single-use exchange")
 struct GatewayOAuthExchangeTests {
   private let callbackURL = URL(string: "https://catbird.blue/oauth/callback")!
-  private let loginURL = URL(string: "https://api.catbird.blue/auth/login?identifier=alice.test")!
-  private let sessionID = "550e8400-e29b-41d4-a716-446655440000"
+  private let gatewayURL = URL(string: "https://api.catbird.blue")!
 
-  @Test("authentication manager activates only legacy compatibility")
-  func authenticationManagerWiring() throws {
+  @Test("legacy URL callback ingestion is absent from production wiring")
+  func legacyCallbackIngestionRemoved() throws {
     let testsURL = URL(fileURLWithPath: #filePath)
-    let sourceURL = testsURL.deletingLastPathComponent()
-      .deletingLastPathComponent()
-      .appendingPathComponent("Catbird/Core/State/AuthManager.swift")
-    let source = try String(contentsOf: sourceURL, encoding: .utf8)
-
-    #expect(source.contains("GatewayOAuthLegacyCallback("))
-    let consume = try #require(source.range(of: "gatewayOAuthLegacyCallback.consume(url)"))
-    let handoff = try #require(source.range(of: "internalCallback.fragment = \"session_id=\\(sessionID)\""))
-    #expect(consume.lowerBound < handoff.lowerBound)
-    #expect(!source.contains("gatewayOAuthExchange.redeem(url)"))
-    #expect(!source.contains("GatewayOAuthExchange("))
-  }
-
-  @Test("login URL remains unchanged and an exact legacy callback succeeds once")
-  func validLegacyCallback() async throws {
-    let callback = GatewayOAuthLegacyCallback(callbackURL: callbackURL)
-    #expect(try await callback.prepareLogin(loginURL) == loginURL)
-
-    let result = try await callback.consume(
-      URL(string: "https://catbird.blue/oauth/callback#session_id=\(sessionID)")!)
-    #expect(result == sessionID)
-
-    await #expect(throws: GatewayOAuthLegacyCallbackError.unauthorized) {
-      try await callback.consume(
-        URL(string: "https://catbird.blue/oauth/callback#session_id=\(sessionID)")!)
-    }
-  }
-
-  @Test("callback requires an active unexpired login attempt")
-  func attemptRequiredAndExpiring() async throws {
-    let clock = TestUptime()
-    let callback = GatewayOAuthLegacyCallback(callbackURL: callbackURL, uptime: { clock.value })
-    let validURL = URL(string: "https://catbird.blue/oauth/callback#session_id=\(sessionID)")!
-
-    await #expect(throws: GatewayOAuthLegacyCallbackError.unauthorized) {
-      try await callback.consume(validURL)
-    }
-    _ = try await callback.prepareLogin(loginURL)
-    clock.value = 60.001
-    await #expect(throws: GatewayOAuthLegacyCallbackError.unauthorized) {
-      try await callback.consume(validURL)
-    }
-  }
-
-  @Test("callback URL and session ID validation fail closed")
-  func invalidCallbacks() async throws {
-    let invalidURLs = [
-      "http://catbird.blue/oauth/callback#session_id=\(sessionID)",
-      "https://catbird.blue.evil.example/oauth/callback#session_id=\(sessionID)",
-      "https://catbird.blue@evil.example/oauth/callback#session_id=\(sessionID)",
-      "https://user@catbird.blue/oauth/callback#session_id=\(sessionID)",
-      "https://catbird.blue:444/oauth/callback#session_id=\(sessionID)",
-      "https://catbird.blue/oauth/other#session_id=\(sessionID)",
-      "https://catbird.blue/oauth/callback?session_id=\(sessionID)",
-      "https://catbird.blue/oauth/callback?next=%2F#session_id=\(sessionID)",
-      "https://catbird.blue/oauth/callback#session_id=\(sessionID)&extra=value",
-      "https://catbird.blue/oauth/callback#extra=value&session_id=\(sessionID)",
-      "https://catbird.blue/oauth/callback#session_id=",
-      "https://catbird.blue/oauth/callback#session_id=a%26b",
-      "https://catbird.blue/oauth/callback#session_id=a%25b",
-      "https://catbird.blue/oauth/callback#session_id=a=b",
-      "https://catbird.blue/oauth/callback#session_id=550E8400-E29B-41D4-A716-446655440000",
-      "https://catbird.blue/oauth/callback#session_id=550e8400e29b41d4a716446655440000",
-      "https://catbird.blue/oauth/callback#session_id=550e8400-e29b-41d4-a716-44665544000",
-      "https://catbird.blue/oauth/callback#session_id=550e8400-e29b-41d4-a716-4466554400000",
+    let repositoryURL = testsURL.deletingLastPathComponent().deletingLastPathComponent()
+    let sourcePaths = [
+      "Catbird/App/CatbirdApp.swift",
+      "Catbird/Core/Networking/GatewayOAuthExchange.swift",
+      "Catbird/Core/State/AuthManager.swift",
+      "Catbird/Features/Auth/Views/LoginView.swift",
+      "Catbird/Features/Auth/Views/AccountSwitcherView.swift",
     ]
 
-    for rawURL in invalidURLs {
-      let callback = GatewayOAuthLegacyCallback(callbackURL: callbackURL)
-      _ = try await callback.prepareLogin(loginURL)
-      await #expect(throws: GatewayOAuthLegacyCallbackError.unauthorized, "\(rawURL)") {
-        try await callback.consume(URL(string: rawURL)!)
-      }
+    let sources = try sourcePaths.map { relativePath in
+      try String(
+        contentsOf: repositoryURL.appendingPathComponent(relativePath),
+        encoding: .utf8
+      )
     }
 
-    let oversized = String(repeating: "a", count: 513)
-    let oversizedURL = try #require(
-      legacyCallbackURL(sessionIDFragmentValue: oversized))
-    let oversizedCallback = GatewayOAuthLegacyCallback(callbackURL: callbackURL)
-    _ = try await oversizedCallback.prepareLogin(loginURL)
-    await #expect(throws: GatewayOAuthLegacyCallbackError.unauthorized) {
-      try await oversizedCallback.consume(oversizedURL)
-    }
-
+    #expect(sources.allSatisfy { !$0.contains("GatewayOAuthLegacyCallback") })
+    #expect(sources.allSatisfy { !$0.contains("gatewayOAuthLegacyCallback") })
+    #expect(sources.allSatisfy { !$0.contains("callback#session_id") })
+    #expect(sources.allSatisfy { !$0.contains("consume(url)") })
+    #expect(sources.joined().contains("gatewayOAuthExchange.redeem(url)"))
   }
 
-  @Test("callback path must be the literal percent-encoded path")
-  func encodedCallbackPathIsRejected() async throws {
-    let callback = GatewayOAuthLegacyCallback(callbackURL: callbackURL)
-    _ = try await callback.prepareLogin(loginURL)
-
-    await #expect(throws: GatewayOAuthLegacyCallbackError.unauthorized) {
-      try await callback.consume(
-        URL(string: "https://catbird.blue/oauth/%63allback#session_id=\(sessionID)")!)
-    }
-  }
-
-  @Test("a canonical lowercase hyphenated UUID session ID is preserved")
-  func canonicalUUIDSessionID() async throws {
-    let callback = GatewayOAuthLegacyCallback(callbackURL: callbackURL)
-    _ = try await callback.prepareLogin(loginURL)
-    let callbackURL = try #require(legacyCallbackURL(sessionIDFragmentValue: sessionID))
-    #expect(try await callback.consume(callbackURL) == sessionID)
-  }
-
-  @Test("fragment field name must be literal")
-  func rawFragmentFieldName() async throws {
-    let encodedNameCallback = GatewayOAuthLegacyCallback(callbackURL: callbackURL)
-    _ = try await encodedNameCallback.prepareLogin(loginURL)
-    await #expect(throws: GatewayOAuthLegacyCallbackError.unauthorized) {
-      try await encodedNameCallback.consume(
-        URL(string: "https://catbird.blue/oauth/callback#session%5Fid=\(sessionID)")!)
-    }
-
-  }
-
-  @Test("auth views clear a prepared legacy attempt on every pre-callback exit")
+  @Test("auth views clear a prepared exchange attempt on every pre-callback exit")
   func authViewPendingAttemptCleanupWiring() throws {
     let testsURL = URL(fileURLWithPath: #filePath)
     let repositoryURL = testsURL.deletingLastPathComponent().deletingLastPathComponent()
@@ -144,112 +50,504 @@ struct GatewayOAuthExchangeTests {
 
     #expect(loginSource.contains("private func cancelAuthenticationTaskAndPendingAttempt()"))
     #expect(loginSource.contains("await cancelPendingAttemptBeforeCallback()"))
-    #expect(
-      loginSource.contains(
-        ".onDisappear {\n            if !isLoggingIn {\n                cancelAuthenticationTaskAndPendingAttempt()"
-      )
-    )
-    #expect(!loginSource.contains(".onDisappear {\n            cancelAuthenticationTaskAndPendingAttempt()"))
-    let cancelAction = try #require(
-      loginSource.range(of: "private func cancelAuthentication()")
-    )
-    let timeoutAction = try #require(
-      loginSource.range(of: "private func startTimeoutCountdown()")
-    )
-    #expect(
-      loginSource[cancelAction.lowerBound..<timeoutAction.lowerBound]
-        .contains("cancelAuthenticationTaskAndPendingAttempt()")
-    )
     #expect(switcherSource.contains("private func cancelAuthenticationTaskAndPendingAttempt()"))
     #expect(switcherSource.contains("await cancelPendingAttemptBeforeCallback()"))
-    #expect(switcherSource.contains(".onDisappear(perform: cancelAuthenticationTaskAndPendingAttempt)"))
-    #expect(
-      switcherSource.contains(
-        "Button(\"Cancel\", systemImage: \"xmark\") {\n            cancelAuthenticationTaskAndPendingAttempt()\n            isAddingAccount = false"
-      )
-    )
   }
 
-  @Test("omitted and explicit default HTTPS ports are equivalent")
+  @Test("gateway callback secrets are absent from callback logging calls")
+  func gatewayCallbackSecretsAreNotLogged() throws {
+    let testsURL = URL(fileURLWithPath: #filePath)
+    let repositoryURL = testsURL.deletingLastPathComponent().deletingLastPathComponent()
+    let exchangeSource = try String(
+      contentsOf: repositoryURL.appendingPathComponent(
+        "Catbird/Core/Networking/GatewayOAuthExchange.swift"),
+      encoding: .utf8
+    )
+    let authSource = try String(
+      contentsOf: repositoryURL.appendingPathComponent("Catbird/Core/State/AuthManager.swift"),
+      encoding: .utf8
+    )
+    let appSource = try String(
+      contentsOf: repositoryURL.appendingPathComponent("Catbird/App/CatbirdApp.swift"),
+      encoding: .utf8
+    )
+    let handlerSource = try String(
+      contentsOf: repositoryURL.appendingPathComponent(
+        "Catbird/Core/Networking/URLHandler.swift"),
+      encoding: .utf8
+    )
+
+    let authCallback = try sourceScope(
+      authSource,
+      from: "  func handleGatewayCallback(_ url: URL) async throws {",
+      to: "  func cancelGatewayOAuthFlow() async {"
+    )
+    let appCallback = try sourceScope(
+      appSource,
+      from: "      .onOpenURL { url in",
+      to: "          } else if url.scheme == \"blue.catbird\""
+    )
+    let handlerCallback = try sourceScope(
+      handlerSource,
+      from: "    private func handleOAuthCallback(_ url: URL) {",
+      to: "    // MARK: - In-App Browser"
+    )
+    let callbackLogging = [
+      loggingCalls(in: exchangeSource),
+      loggingCalls(in: authCallback),
+      loggingCalls(in: appCallback),
+      loggingCalls(in: handlerCallback),
+    ].joined(separator: "\n")
+    let forbiddenValueReferences = [
+      "url.absoluteString",
+      "url.query",
+      "queryItems",
+      #"\(url)"#,
+      #"\(url,"#,
+      #"\(code"#,
+      "sessionID",
+      "session_id",
+      "browserNonce",
+      "internalCallback",
+      "payload.sessionID",
+    ]
+
+    for forbidden in forbiddenValueReferences {
+      #expect(!callbackLogging.contains(forbidden))
+    }
+  }
+
+  @Test("login binds a cryptographic nonce and the exact callback URL")
+  func loginBinding() async throws {
+    let exchange = GatewayOAuthExchange(
+      gatewayURL: gatewayURL,
+      callbackURL: callbackURL,
+      send: { _ in throw GatewayOAuthExchangeError.unauthorized }
+    )
+
+    let loginURL = try await exchange.prepareLogin(
+      URL(string: "https://api.catbird.blue/auth/login?identifier=alice.test")!
+    )
+    let components = try #require(URLComponents(url: loginURL, resolvingAgainstBaseURL: false))
+    let query = Dictionary(
+      uniqueKeysWithValues: (components.queryItems ?? []).map { ($0.name, $0.value) })
+    let nonce = try #require(query["browser_nonce"] ?? nil)
+
+    #expect(query["identifier"] == "alice.test")
+    #expect(query["redirect_to"] == callbackURL.absoluteString)
+    #expect(nonce.count == 43)
+    #expect(nonce.allSatisfy { $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" })
+  }
+
+  @Test("a second login cannot replace a live pending browser nonce")
+  func overlappingLoginRejected() async throws {
+    let exchange = GatewayOAuthExchange(
+      gatewayURL: gatewayURL,
+      callbackURL: callbackURL,
+      send: { _ in throw GatewayOAuthExchangeError.unauthorized }
+    )
+    _ = try await exchange.prepareLogin(URL(string: "https://api.catbird.blue/auth/login")!)
+
+    await #expect(throws: GatewayOAuthExchangeError.flowInProgress) {
+      try await exchange.prepareLogin(URL(string: "https://api.catbird.blue/auth/login")!)
+    }
+  }
+
+  @Test("a native nonce expires after sixty seconds")
+  func nativeNonceExpiry() async throws {
+    let clock = TestUptime()
+    let exchange = GatewayOAuthExchange(
+      gatewayURL: gatewayURL,
+      callbackURL: callbackURL,
+      uptime: { clock.value },
+      send: { _ in throw GatewayOAuthExchangeError.unauthorized }
+    )
+    _ = try await exchange.prepareLogin(URL(string: "https://api.catbird.blue/auth/login")!)
+    clock.value = 60.001
+
+    await #expect(throws: GatewayOAuthExchangeError.unauthorized) {
+      try await exchange.redeem(
+        URL(
+          string:
+            "https://catbird.blue/oauth/callback?code=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ")!
+      )
+    }
+  }
+
+  @Test("exchange transport rejects redirects and streamed responses over budget")
+  func transportBoundaries() throws {
+    #expect(GatewayOAuthExchangeTransport.redirectTarget == nil)
+    var buffer = Data(repeating: 65, count: GatewayOAuthExchange.maximumResponseBytes)
+    try GatewayOAuthExchangeTransport.append(
+      Data(), to: &buffer, maximumBytes: GatewayOAuthExchange.maximumResponseBytes)
+    #expect(throws: GatewayOAuthExchangeError.unauthorized) {
+      try GatewayOAuthExchangeTransport.append(
+        Data([66]), to: &buffer, maximumBytes: GatewayOAuthExchange.maximumResponseBytes)
+    }
+  }
+
+  @Test("cancelling transport stops its underlying URL session task")
+  func transportCancellation() async throws {
+    let probe = TransportCancellationProbe()
+    TransportCancellationURLProtocol.registry.install(probe)
+    defer { TransportCancellationURLProtocol.registry.install(nil) }
+
+    let transport = GatewayOAuthExchangeTransport(
+      maximumBytes: GatewayOAuthExchange.maximumResponseBytes,
+      protocolClasses: [TransportCancellationURLProtocol.self]
+    )
+    let request = URLRequest(url: gatewayURL.appendingPathComponent("auth/exchange"))
+    let operation = Task {
+      try await transport.send(request)
+    }
+    await probe.waitUntilStarted()
+    operation.cancel()
+
+    do {
+      _ = try await operation.value
+      Issue.record("cancelled transport unexpectedly returned a response")
+    } catch {
+      // Cancellation must fail the send and stop the underlying URL loading task.
+    }
+    await probe.waitUntilStopped()
+    #expect(probe.stopCount == 1)
+  }
+
+  @Test("an absolute deadline wins even when the sender ignores cancellation")
+  func absoluteRequestDeadline() async throws {
+    let sendGate = ManualAsyncGate()
+    let deadlineGate = ManualAsyncGate()
+    let response = HTTPURLResponse(
+      url: gatewayURL.appendingPathComponent("auth/exchange"),
+      statusCode: 200,
+      httpVersion: nil,
+      headerFields: ["Content-Type": "application/json"]
+    )!
+    let exchange = GatewayOAuthExchange(
+      gatewayURL: gatewayURL,
+      callbackURL: callbackURL,
+      send: { _ in
+        await sendGate.wait()
+        return (
+          Data(#"{"session_id":"550e8400-e29b-41d4-a716-446655440000"}"#.utf8),
+          response
+        )
+      },
+      waitForDeadline: {
+        await deadlineGate.wait()
+      }
+    )
+    _ = try await exchange.prepareLogin(URL(string: "https://api.catbird.blue/auth/login")!)
+
+    let redemption = Task {
+      try await exchange.redeem(
+        URL(
+          string:
+            "https://catbird.blue/oauth/callback?code=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ"
+        )!
+      )
+    }
+    await sendGate.waitUntilEntered()
+    await deadlineGate.waitUntilEntered()
+    await deadlineGate.open()
+
+    await #expect(throws: GatewayOAuthExchangeError.unauthorized) {
+      try await redemption.value
+    }
+    await sendGate.open()
+  }
+
+  @Test("cancelling the flow invalidates an in-flight exchange response")
+  func cancelledInFlightExchange() async throws {
+    let sendGate = ManualAsyncGate()
+    let response = HTTPURLResponse(
+      url: gatewayURL.appendingPathComponent("auth/exchange"),
+      statusCode: 200,
+      httpVersion: nil,
+      headerFields: ["Content-Type": "application/json"]
+    )!
+    let exchange = GatewayOAuthExchange(
+      gatewayURL: gatewayURL,
+      callbackURL: callbackURL,
+      send: { _ in
+        await sendGate.wait()
+        return (
+          Data(#"{"session_id":"550e8400-e29b-41d4-a716-446655440000"}"#.utf8),
+          response
+        )
+      }
+    )
+    _ = try await exchange.prepareLogin(URL(string: "https://api.catbird.blue/auth/login")!)
+
+    let redemption = Task {
+      try await exchange.redeem(
+        URL(
+          string:
+            "https://catbird.blue/oauth/callback?code=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ"
+        )!
+      )
+    }
+    await sendGate.waitUntilEntered()
+    await exchange.cancelPendingLogin()
+    _ = try await exchange.prepareLogin(
+      URL(string: "https://api.catbird.blue/auth/login?identifier=next-account.test")!
+    )
+    await sendGate.open()
+
+    await #expect(throws: GatewayOAuthExchangeError.unauthorized) {
+      try await redemption.value
+    }
+  }
+
+  @Test("callback redemption sends JSON to the fixed endpoint with exact Origin")
+  func redemptionRequest() async throws {
+    let recorder = RequestRecorder(
+      responseData: Data(
+        #"{"session_id":"550e8400-e29b-41d4-a716-446655440000"}"#.utf8),
+      response: HTTPURLResponse(
+        url: gatewayURL.appendingPathComponent("auth/exchange"),
+        statusCode: 200,
+        httpVersion: nil,
+        headerFields: ["Content-Type": "application/json"]
+      )!
+    )
+    let exchange = GatewayOAuthExchange(
+      gatewayURL: gatewayURL,
+      callbackURL: callbackURL,
+      send: { request in await recorder.send(request) }
+    )
+    let loginURL = try await exchange.prepareLogin(
+      URL(string: "https://api.catbird.blue/auth/login")!
+    )
+    let loginComponents = try #require(URLComponents(url: loginURL, resolvingAgainstBaseURL: false))
+    let nonce = try #require(
+      loginComponents.queryItems?.first(where: { $0.name == "browser_nonce" })?.value)
+
+    let sessionID = try await exchange.redeem(
+      URL(
+        string:
+          "https://catbird.blue/oauth/callback?code=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ")!
+    )
+    let request = try #require(await recorder.request)
+    let body = try #require(request.httpBody)
+    let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: String])
+
+    #expect(sessionID == "550e8400-e29b-41d4-a716-446655440000")
+    #expect(request.url == gatewayURL.appendingPathComponent("auth/exchange"))
+    #expect(request.httpMethod == "POST")
+    #expect(request.value(forHTTPHeaderField: "Origin") == "https://catbird.blue")
+    #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/json")
+    #expect(request.value(forHTTPHeaderField: "Accept") == "application/json")
+    #expect(
+      json == [
+        "code": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ",
+        "browser_nonce": nonce,
+      ])
+  }
+
+  @Test("malformed callback consumes pending nonce and replay fails locally")
+  func malformedCallbackAndReplay() async throws {
+    let recorder = RequestRecorder(
+      responseData: Data(
+        #"{"session_id":"550e8400-e29b-41d4-a716-446655440000"}"#.utf8),
+      response: HTTPURLResponse(
+        url: gatewayURL.appendingPathComponent("auth/exchange"),
+        statusCode: 200,
+        httpVersion: nil,
+        headerFields: ["Content-Type": "application/json"]
+      )!
+    )
+    let exchange = GatewayOAuthExchange(
+      gatewayURL: gatewayURL,
+      callbackURL: callbackURL,
+      send: { request in await recorder.send(request) }
+    )
+    _ = try await exchange.prepareLogin(URL(string: "https://api.catbird.blue/auth/login")!)
+
+    await #expect(throws: GatewayOAuthExchangeError.unauthorized) {
+      try await exchange.redeem(
+        URL(
+          string:
+            "https://evil.example/oauth/callback?code=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ")!
+      )
+    }
+    await #expect(throws: GatewayOAuthExchangeError.unauthorized) {
+      try await exchange.redeem(
+        URL(
+          string:
+            "https://catbird.blue/oauth/callback?code=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ")!
+      )
+    }
+    #expect(await recorder.request == nil)
+  }
+
+  @Test("wrong origin, malformed code, fragments, and extra query fields fail closed")
+  func structuralCallbackValidation() async throws {
+    let invalidURLs = [
+      "http://catbird.blue/oauth/callback?code=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ",
+      "https://catbird.blue.evil.example/oauth/callback?code=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ",
+      "https://catbird.blue/oauth/callback?code=short",
+      "https://catbird.blue/oauth/callback?code=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ&session_id=leak",
+      "https://catbird.blue/oauth/callback?code=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ#fragment",
+    ]
+
+    for rawURL in invalidURLs {
+      let exchange = GatewayOAuthExchange(
+        gatewayURL: gatewayURL,
+        callbackURL: callbackURL,
+        send: { _ in throw GatewayOAuthExchangeError.unauthorized }
+      )
+      _ = try await exchange.prepareLogin(URL(string: "https://api.catbird.blue/auth/login")!)
+      await #expect(throws: GatewayOAuthExchangeError.unauthorized) {
+        try await exchange.redeem(URL(string: rawURL)!)
+      }
+    }
+  }
+
+  @Test("HTTPS default port is equivalent when omitted or explicit")
   func defaultHTTPSPortNormalization() async throws {
-    for (configured, received) in [
+    for (configured, callback) in [
       (
         "https://catbird.blue/oauth/callback",
-        "https://catbird.blue:443/oauth/callback#session_id=\(sessionID)"
+        "https://catbird.blue:443/oauth/callback?code=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ"
       ),
       (
         "https://catbird.blue:443/oauth/callback",
-        "https://catbird.blue/oauth/callback#session_id=\(sessionID)"
+        "https://catbird.blue/oauth/callback?code=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ"
       ),
     ] {
-      let callback = GatewayOAuthLegacyCallback(callbackURL: URL(string: configured)!)
-      _ = try await callback.prepareLogin(loginURL)
-      #expect(try await callback.consume(URL(string: received)!) == sessionID)
+      let response = HTTPURLResponse(
+        url: gatewayURL.appendingPathComponent("auth/exchange"),
+        statusCode: 200,
+        httpVersion: nil,
+        headerFields: ["Content-Type": "application/json"]
+      )!
+      let exchange = GatewayOAuthExchange(
+        gatewayURL: gatewayURL,
+        callbackURL: URL(string: configured)!,
+        send: { request in
+          #expect(request.value(forHTTPHeaderField: "Origin") == "https://catbird.blue")
+          return (
+            Data(#"{"session_id":"550e8400-e29b-41d4-a716-446655440000"}"#.utf8),
+            response
+          )
+        }
+      )
+      _ = try await exchange.prepareLogin(URL(string: "https://api.catbird.blue/auth/login")!)
+      #expect(
+        try await exchange.redeem(URL(string: callback)!)
+          == "550e8400-e29b-41d4-a716-446655440000")
     }
   }
 
-  @Test("a malformed callback consumes the pending attempt")
-  func malformedCallbackConsumesAttempt() async throws {
-    let callback = GatewayOAuthLegacyCallback(callbackURL: callbackURL)
-    _ = try await callback.prepareLogin(loginURL)
-
-    await #expect(throws: GatewayOAuthLegacyCallbackError.unauthorized) {
-      try await callback.consume(
-        URL(string: "https://evil.example/oauth/callback#session_id=\(sessionID)")!)
-    }
-    await #expect(throws: GatewayOAuthLegacyCallbackError.unauthorized) {
-      try await callback.consume(
-        URL(string: "https://catbird.blue/oauth/callback#session_id=\(sessionID)")!)
+  @Test("non-default HTTPS callback ports are rejected")
+  func nonDefaultHTTPSPortRejected() async throws {
+    let exchange = GatewayOAuthExchange(
+      gatewayURL: gatewayURL,
+      callbackURL: callbackURL,
+      send: { _ in throw GatewayOAuthExchangeError.unauthorized }
+    )
+    _ = try await exchange.prepareLogin(URL(string: "https://api.catbird.blue/auth/login")!)
+    await #expect(throws: GatewayOAuthExchangeError.unauthorized) {
+      try await exchange.redeem(
+        URL(
+          string:
+            "https://catbird.blue:444/oauth/callback?code=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ"
+        )!
+      )
     }
   }
 
-  @Test("a live attempt blocks replacement and cancellation clears it")
-  func overlappingAndCancelledAttempts() async throws {
-    let callback = GatewayOAuthLegacyCallback(callbackURL: callbackURL)
-    _ = try await callback.prepareLogin(loginURL)
-
-    await #expect(throws: GatewayOAuthLegacyCallbackError.flowInProgress) {
-      try await callback.prepareLogin(loginURL)
-    }
-
-    await callback.cancelPendingLogin()
-    await #expect(throws: GatewayOAuthLegacyCallbackError.unauthorized) {
-      try await callback.consume(
-        URL(string: "https://catbird.blue/oauth/callback#session_id=\(sessionID)")!)
-    }
-    #expect(try await callback.prepareLogin(loginURL) == loginURL)
+  @Test("transport eagerly initializes its session and cancels unknown delegate tasks")
+  func eagerTransportAndUnknownTaskPolicy() {
+    let transport = GatewayOAuthExchangeTransport(
+      maximumBytes: GatewayOAuthExchange.maximumResponseBytes)
+    #expect(transport.hasInitializedSession)
+    #expect(
+      GatewayOAuthExchangeTransport.responseDisposition(hasPendingRequest: false) == .cancel)
+    #expect(
+      GatewayOAuthExchangeTransport.responseDisposition(hasPendingRequest: true) == .allow)
   }
 
-  @Test("invalid configured callbacks fail without creating an attempt")
-  func invalidConfiguration() async throws {
-    let invalidConfiguredCallbacks = [
-      "http://catbird.blue/oauth/callback",
-      "https://evil.example/oauth/callback",
-      "https://catbird.blue.evil.example/oauth/callback",
-      "https://user@catbird.blue/oauth/callback",
-      "https://user:password@catbird.blue/oauth/callback",
-      "https://catbird.blue/oauth/callback?next=%2F",
-      "https://catbird.blue/oauth/callback#session_id=configured",
-      "https://catbird.blue/oauth/other",
-      "https://catbird.blue:444/oauth/callback",
+  @Test("authentication manager uses one canonical gateway URL")
+  func canonicalGatewayURL() {
+    #expect(AuthenticationManager.gatewayURL == CatbirdGatewayConfiguration.current.origin)
+  }
+
+  @Test("non-success and oversized or malformed responses fail closed")
+  func boundedResponse() async throws {
+    let cases: [(Data, Int, [String: String])] = [
+      (
+        Data(#"{"session_id":"550e8400-e29b-41d4-a716-446655440000"}"#.utf8), 401,
+        ["Content-Type": "application/json"]
+      ),
+      (
+        Data(repeating: 65, count: GatewayOAuthExchange.maximumResponseBytes + 1), 200,
+        ["Content-Type": "application/json"]
+      ),
+      (
+        Data(#"{"session_id":"550e8400-e29b-41d4-a716-446655440000"}"#.utf8), 200,
+        ["Content-Type": "text/plain"]
+      ),
+      (Data(#"{"session_id":""}"#.utf8), 200, ["Content-Type": "application/json"]),
     ]
-    let validURL = URL(string: "https://catbird.blue/oauth/callback#session_id=\(sessionID)")!
 
-    for rawURL in invalidConfiguredCallbacks {
-      let callback = GatewayOAuthLegacyCallback(callbackURL: URL(string: rawURL)!)
-      await #expect(throws: GatewayOAuthLegacyCallbackError.configuration, "\(rawURL)") {
-        try await callback.prepareLogin(loginURL)
-      }
-      await #expect(throws: GatewayOAuthLegacyCallbackError.unauthorized, "\(rawURL)") {
-        try await callback.consume(validURL)
+    for (data, status, headers) in cases {
+      let response = HTTPURLResponse(
+        url: gatewayURL.appendingPathComponent("auth/exchange"),
+        statusCode: status,
+        httpVersion: nil,
+        headerFields: headers
+      )!
+      let exchange = GatewayOAuthExchange(
+        gatewayURL: gatewayURL,
+        callbackURL: callbackURL,
+        send: { _ in (data, response) }
+      )
+      _ = try await exchange.prepareLogin(URL(string: "https://api.catbird.blue/auth/login")!)
+
+      await #expect(throws: GatewayOAuthExchangeError.unauthorized) {
+        try await exchange.redeem(
+          URL(
+            string:
+              "https://catbird.blue/oauth/callback?code=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ"
+          )!)
       }
     }
   }
 
-  private func legacyCallbackURL(sessionIDFragmentValue: String) -> URL? {
-    var components = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false)
-    components?.fragment = "session_id=\(sessionIDFragmentValue)"
-    return components?.url
+  @Test("exchange accepts only canonical lowercase UUID session identifiers")
+  func canonicalSessionIDGrammar() async throws {
+    let invalidSessionIDs = [
+      "session-123",
+      "550E8400-E29B-41D4-A716-446655440000",
+      "550e8400-e29b-41d4-a716-446655440000#fragment",
+      String(repeating: "a", count: 513),
+    ]
+
+    for sessionID in invalidSessionIDs {
+      let response = HTTPURLResponse(
+        url: gatewayURL.appendingPathComponent("auth/exchange"),
+        statusCode: 200,
+        httpVersion: nil,
+        headerFields: ["Content-Type": "application/json"]
+      )!
+      let responseData = try JSONSerialization.data(withJSONObject: ["session_id": sessionID])
+      let exchange = GatewayOAuthExchange(
+        gatewayURL: gatewayURL,
+        callbackURL: callbackURL,
+        send: { _ in (responseData, response) }
+      )
+      _ = try await exchange.prepareLogin(URL(string: "https://api.catbird.blue/auth/login")!)
+
+      await #expect(throws: GatewayOAuthExchangeError.unauthorized) {
+        try await exchange.redeem(
+          URL(
+            string:
+              "https://catbird.blue/oauth/callback?code=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ"
+          )!)
+      }
+    }
   }
 }
 
@@ -260,5 +558,185 @@ private final class TestUptime: @unchecked Sendable {
   var value: TimeInterval {
     get { lock.withLock { storedValue } }
     set { lock.withLock { storedValue = newValue } }
+  }
+}
+
+private actor RequestRecorder {
+  private(set) var request: URLRequest?
+  let responseData: Data
+  let response: URLResponse
+
+  init(responseData: Data, response: URLResponse) {
+    self.responseData = responseData
+    self.response = response
+  }
+
+  func send(_ request: URLRequest) -> (Data, URLResponse) {
+    self.request = request
+    return (responseData, response)
+  }
+}
+
+private actor ManualAsyncGate {
+  private var entered = false
+  private var isOpen = false
+  private var waiters: [CheckedContinuation<Void, Never>] = []
+
+  func wait() async {
+    entered = true
+    guard !isOpen else { return }
+    await withCheckedContinuation { continuation in
+      waiters.append(continuation)
+    }
+  }
+
+  func waitUntilEntered() async {
+    while !entered {
+      await Task.yield()
+    }
+  }
+
+  func open() {
+    isOpen = true
+    let pending = waiters
+    waiters.removeAll()
+    for waiter in pending {
+      waiter.resume()
+    }
+  }
+}
+
+private final class TransportCancellationProbe: @unchecked Sendable {
+  private let lock = NSLock()
+  private var started = false
+  private var storedStopCount = 0
+  private var startWaiters: [CheckedContinuation<Void, Never>] = []
+  private var stopWaiters: [CheckedContinuation<Void, Never>] = []
+
+  var stopCount: Int {
+    lock.withLock { storedStopCount }
+  }
+
+  func markStarted() {
+    let waiters = lock.withLock {
+      started = true
+      let waiters = startWaiters
+      startWaiters.removeAll()
+      return waiters
+    }
+    for waiter in waiters {
+      waiter.resume()
+    }
+  }
+
+  func markStopped() {
+    let waiters = lock.withLock {
+      storedStopCount += 1
+      let waiters = stopWaiters
+      stopWaiters.removeAll()
+      return waiters
+    }
+    for waiter in waiters {
+      waiter.resume()
+    }
+  }
+
+  func waitUntilStarted() async {
+    await withCheckedContinuation { continuation in
+      let shouldResume = lock.withLock {
+        guard !started else { return true }
+        startWaiters.append(continuation)
+        return false
+      }
+      if shouldResume {
+        continuation.resume()
+      }
+    }
+  }
+
+  func waitUntilStopped() async {
+    await withCheckedContinuation { continuation in
+      let shouldResume = lock.withLock {
+        guard storedStopCount == 0 else { return true }
+        stopWaiters.append(continuation)
+        return false
+      }
+      if shouldResume {
+        continuation.resume()
+      }
+    }
+  }
+}
+
+private func sourceScope(_ source: String, from start: String, to end: String) throws -> String {
+  let startRange = try #require(source.range(of: start))
+  let endRange = try #require(source.range(of: end, range: startRange.upperBound..<source.endIndex))
+  return String(source[startRange.lowerBound..<endRange.lowerBound])
+}
+
+private func loggingCalls(in source: String) -> String {
+  var calls: [String] = []
+  var current: [String] = []
+  var parenthesisDepth = 0
+
+  for line in source.components(separatedBy: .newlines) {
+    if current.isEmpty {
+      guard line.contains("logger.") || line.contains("print(") else { continue }
+    }
+
+    current.append(line)
+    parenthesisDepth += line.reduce(into: 0) { depth, character in
+      if character == "(" {
+        depth += 1
+      } else if character == ")" {
+        depth -= 1
+      }
+    }
+
+    if parenthesisDepth <= 0 {
+      calls.append(current.joined(separator: "\n"))
+      current.removeAll()
+      parenthesisDepth = 0
+    }
+  }
+
+  if !current.isEmpty {
+    calls.append(current.joined(separator: "\n"))
+  }
+  return calls.joined(separator: "\n")
+}
+
+private final class TransportCancellationProbeRegistry: @unchecked Sendable {
+  private let lock = NSLock()
+  private var probe: TransportCancellationProbe?
+
+  func install(_ probe: TransportCancellationProbe?) {
+    lock.withLock {
+      self.probe = probe
+    }
+  }
+
+  func current() -> TransportCancellationProbe? {
+    lock.withLock { probe }
+  }
+}
+
+private final class TransportCancellationURLProtocol: URLProtocol, @unchecked Sendable {
+  static let registry = TransportCancellationProbeRegistry()
+
+  override class func canInit(with request: URLRequest) -> Bool {
+    true
+  }
+
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    request
+  }
+
+  override func startLoading() {
+    Self.registry.current()?.markStarted()
+  }
+
+  override func stopLoading() {
+    Self.registry.current()?.markStopped()
   }
 }


### PR DESCRIPTION
## Summary
- remove legacy OAuth callback/session ingestion from Catbird
- bind callback redemption to the initiating nonce, exact origin, single active flow, and a hard deadline
- cancel obsolete exchanges and underlying transport exactly once
- reject redirects, oversized responses, malformed callbacks, and non-canonical session IDs
- add privacy regression coverage preventing callback secrets from reaching logs

## Verification
- `GatewayOAuthExchangeTests`: 19/19 passed on exact head
- independent adversarial review: APPROVE
- exact reviewed commit: `0680a5cdc06de3711ec8d40afb158e9999716a29`

Part of Wave 1 security remediation; staging OAuth and stored-session E2E evidence remain separate rollout gates.